### PR TITLE
Add idempotent pytest coverage for deploy planner and local runtime helpers

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -2,43 +2,42 @@ name: Backend Pytest
 
 "on":
   pull_request:
-      paths:
-            - "backend/**"
-                  - ".github/workflows/backend-pytest.yml"
-                    push:
-                        branches:
-                              - main
-                                    - issue-17-backend-pytest
-                                        paths:
-                                              - "backend/**"
-                                                    - ".github/workflows/backend-pytest.yml"
-                                                      workflow_dispatch:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-pytest.yml"
+  push:
+    branches:
+      - main
+      - issue-17-backend-pytest
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-pytest.yml"
+  workflow_dispatch:
 
-                                                      jobs:
-                                                        backend-pytest:
-                                                            runs-on: ubuntu-latest
-                                                                defaults:
-                                                                      run:
-                                                                              working-directory: backend
+jobs:
+  backend-pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
-                                                                                  steps:
-                                                                                        - name: Check out repository
-                                                                                                uses: actions/checkout@v4
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-                                                                                                      - name: Set up Python
-                                                                                                              uses: actions/setup-python@v5
-                                                                                                                      with:
-                                                                                                                                python-version: "3.11"
-                                                                                                                                          cache: "pip"
-                                                                                                                                                    cache-dependency-path: |
-                                                                                                                                                                backend/requirements.txt
-                                                                                                                                                                            backend/requirements-dev.txt
-                                                                                                                                                                            
-                                                                                                                                                                                  - name: Install backend dependencies
-                                                                                                                                                                                          run: |
-                                                                                                                                                                                                    python -m pip install --upgrade pip
-                                                                                                                                                                                                              pip install -r requirements.txt -r requirements-dev.txt
-                                                                                                                                                                                                              
-                                                                                                                                                                                                                    - name: Run backend pytest suite
-                                                                                                                                                                                                                            run: python -m pytest -q
-                                                                                                                                                                                                                            
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run backend pytest suite
+        run: python -m pytest -q

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -1,6 +1,6 @@
 name: Backend Pytest
 
-on:
+"on":
   pull_request:
       paths:
             - "backend/**"

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -1,0 +1,44 @@
+name: Backend Pytest
+
+on:
+  pull_request:
+      paths:
+            - "backend/**"
+                  - ".github/workflows/backend-pytest.yml"
+                    push:
+                        branches:
+                              - main
+                                    - issue-17-backend-pytest
+                                        paths:
+                                              - "backend/**"
+                                                    - ".github/workflows/backend-pytest.yml"
+                                                      workflow_dispatch:
+
+                                                      jobs:
+                                                        backend-pytest:
+                                                            runs-on: ubuntu-latest
+                                                                defaults:
+                                                                      run:
+                                                                              working-directory: backend
+
+                                                                                  steps:
+                                                                                        - name: Check out repository
+                                                                                                uses: actions/checkout@v4
+
+                                                                                                      - name: Set up Python
+                                                                                                              uses: actions/setup-python@v5
+                                                                                                                      with:
+                                                                                                                                python-version: "3.11"
+                                                                                                                                          cache: "pip"
+                                                                                                                                                    cache-dependency-path: |
+                                                                                                                                                                backend/requirements.txt
+                                                                                                                                                                            backend/requirements-dev.txt
+                                                                                                                                                                            
+                                                                                                                                                                                  - name: Install backend dependencies
+                                                                                                                                                                                          run: |
+                                                                                                                                                                                                    python -m pip install --upgrade pip
+                                                                                                                                                                                                              pip install -r requirements.txt -r requirements-dev.txt
+                                                                                                                                                                                                              
+                                                                                                                                                                                                                    - name: Run backend pytest suite
+                                                                                                                                                                                                                            run: python -m pytest -q
+                                                                                                                                                                                                                            

--- a/backend/README.md
+++ b/backend/README.md
@@ -67,6 +67,17 @@ For complete details and examples:
 
 - [Using `deploy()`](./docs/DEPLOYMENT.md)
 
+## Running the Backend Test Suite
+
+Install the backend dev dependencies and run pytest from the `backend/` directory:
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+python -m pytest
+```
+
+The pytest suite is intentionally safe to rerun. Planner coverage uses fresh `DeployWorkflow` fixtures on every test, and the Docker env-injection helper test replaces container startup with mocks while still verifying that the generated temporary compose file is cleaned up afterward. The older `test_deploy.py` script remains available as a manual Docker integration check, but it is no longer part of the default pytest collection.
+
 ## Current Module Breakdown
 
 - `main.py`: FastAPI app and `POST /deploy` route.

--- a/backend/deployment.py
+++ b/backend/deployment.py
@@ -200,13 +200,6 @@ def deploy(workflow: DeployWorkflow, inject_env: bool = False) -> Dict[str, Any]
         "credentials_by_node": creds_by_node,
     }
 
-def fetch_image_name(node: Node) -> str:
-    """
-    Fetch the image name from the node.
-    This function assumes that the node has an 'image' attribute.
-    """
-    return node.runtime  # Assuming runtime contains the image name for simplicity
-
 if __name__ == "__main__":
     example_workflow = DeployWorkflow(
         nodes=[

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,4 +7,8 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["colorama==0.4.6"]
+dev = ["colorama==0.4.6", "pytest==8.4.1"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,2 +1,3 @@
 # Dev/test-only dependencies for backend scripts (not production runtime)
 colorama==0.4.6
+pytest==8.4.1

--- a/backend/tests/test_deployment_planner.py
+++ b/backend/tests/test_deployment_planner.py
@@ -1,0 +1,187 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import deployment
+from workflow_types import DeployEdge, DeployNode, DeployWorkflow
+
+
+@pytest.fixture
+def linear_workflow() -> DeployWorkflow:
+    return DeployWorkflow(
+        nodes=[
+            DeployNode(id="source", type="sender", out_streams=["json"]),
+            DeployNode(
+                id="plugin-a",
+                type="plugin",
+                runtime="test/plugin-a:latest",
+                in_streams=["json"],
+                out_streams=["bytes"],
+                env_vars={"EXISTING": "1"},
+            ),
+            DeployNode(
+                id="plugin-b",
+                type="plugin",
+                in_streams=["bytes"],
+                env_vars={"PLUGIN_B": "ready"},
+            ),
+        ],
+        edges=[
+            DeployEdge(source="source", target="plugin-a", data="json"),
+            DeployEdge(source="plugin-a", target="plugin-b", data="bytes"),
+        ],
+    )
+
+
+def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWorkflow) -> None:
+    first = deployment.deploy(linear_workflow, inject_env=False)
+    second = deployment.deploy(linear_workflow, inject_env=False)
+
+    assert first == second
+    assert first["node_count"] == 3
+    assert first["edge_count"] == 2
+    assert first["topological_order"] == ["source", "plugin-a", "plugin-b"]
+    assert first["queued_plugins"] == ["plugin-a", "plugin-b"]
+    assert first["assigned_nodes"] == ["plugin-a", "plugin-b"]
+    assert first["adjacency_list"] == {
+        "source": ["plugin-a"],
+        "plugin-a": ["plugin-b"],
+        "plugin-b": [],
+    }
+
+    plugin_a_env = first["env_plan"]["plugin-a"]
+    assert plugin_a_env["EXISTING"] == "1"
+    assert plugin_a_env["NODE_ID"] == "plugin-a"
+    assert plugin_a_env["NODE_TYPE"] == "plugin"
+    assert plugin_a_env["IN_JSON_STREAM_ID"] == "source_plugin-a_json_stream"
+    assert plugin_a_env["OUT_BYTES_STREAM_ID"] == "plugin-a_plugin-b_bytes_stream"
+
+    plugin_b_env = first["env_plan"]["plugin-b"]
+    assert plugin_b_env["PLUGIN_B"] == "ready"
+    assert plugin_b_env["IN_BYTES_STREAM_ID"] == "plugin-a_plugin-b_bytes_stream"
+
+    assert first["credentials_by_node"]["source"]["out_creds"]["json"]["workspace"] == (
+        "source_plugin-a_json_workspace"
+    )
+    assert first["credentials_by_node"]["plugin-b"]["in_creds"]["bytes"]["stream_id"] == (
+        "plugin-a_plugin-b_bytes_stream"
+    )
+
+
+@pytest.mark.parametrize(
+    ("edge", "message"),
+    [
+        (DeployEdge(source="missing", target="plugin-a", data="json"), "Edge source 'missing' not found in nodes"),
+        (DeployEdge(source="source", target="missing", data="json"), "Edge target 'missing' not found in nodes"),
+    ],
+)
+def test_deploy_rejects_unknown_edge_endpoints(edge: DeployEdge, message: str) -> None:
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="source", type="sender", out_streams=["json"]),
+            DeployNode(id="plugin-a", type="plugin", in_streams=["json"]),
+        ],
+        edges=[edge],
+    )
+
+    with pytest.raises(ValueError, match=message):
+        deployment.deploy(workflow)
+
+
+def test_deploy_rejects_cycles() -> None:
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="plugin-a", type="plugin", in_streams=["json"], out_streams=["json"]),
+            DeployNode(id="plugin-b", type="plugin", in_streams=["json"], out_streams=["json"]),
+        ],
+        edges=[
+            DeployEdge(source="plugin-a", target="plugin-b", data="json"),
+            DeployEdge(source="plugin-b", target="plugin-a", data="json"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Cycle detected"):
+        deployment.deploy(workflow)
+
+
+def test_deploy_rejects_stream_contract_mismatch() -> None:
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="source", type="sender", out_streams=["json"]),
+            DeployNode(id="plugin-a", type="plugin", in_streams=["bytes"]),
+        ],
+        edges=[DeployEdge(source="source", target="plugin-a", data="json")],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Stream type json not found in destination plugin-a in streams",
+    ):
+        deployment.deploy(workflow)
+
+
+def test_deploy_infers_streams_when_edge_contract_is_present() -> None:
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="source", type="sender"),
+            DeployNode(id="plugin-a", type="plugin", runtime="test/plugin-a:latest"),
+        ],
+        edges=[DeployEdge(source="source", target="plugin-a", data="parquet")],
+    )
+
+    result = deployment.deploy(workflow)
+
+    assert result["topological_order"] == ["source", "plugin-a"]
+    assert result["env_plan"]["plugin-a"]["IN_PARQUET_STREAM_ID"] == "source_plugin-a_parquet_stream"
+    assert result["credentials_by_node"]["source"]["out_creds"]["parquet"]["data_type"] == "parquet"
+
+
+def test_deploy_injects_env_only_for_plugins_with_images(
+    linear_workflow: DeployWorkflow, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    injected = []
+
+    def fake_inject(env_vars: dict[str, str], image_name: str) -> None:
+        injected.append((image_name, env_vars.copy()))
+
+    monkeypatch.setattr(deployment, "inject_vars_to_image", fake_inject)
+
+    result = deployment.deploy(linear_workflow, inject_env=True)
+
+    assert [image_name for image_name, _ in injected] == ["test/plugin-a:latest"]
+    assert result["injected_nodes"] == ["plugin-a"]
+    assert result["skipped_nodes"] == [
+        {"node_id": "plugin-b", "reason": "No runtime/container image found"}
+    ]
+    assert injected[0][1]["IN_JSON_STREAM_ID"] == "source_plugin-a_json_stream"
+    assert injected[0][1]["OUT_BYTES_STREAM_ID"] == "plugin-a_plugin-b_bytes_stream"
+
+
+def test_inject_vars_to_image_uses_disposable_compose_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(args: list[str], check: bool) -> SimpleNamespace:
+        compose_file = Path(args[3])
+        captured["compose_file"] = compose_file
+        captured["exists_during_run"] = compose_file.exists()
+        captured["content"] = compose_file.read_text()
+        captured["check"] = check
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(deployment.subprocess, "run", fake_run)
+
+    deployment.inject_vars_to_image(
+        {"NODE_ID": "plugin-a", "IN_JSON_STREAM_ID": "stream-1"},
+        "repo/image:latest",
+    )
+
+    compose_file = captured["compose_file"]
+    assert captured["check"] is True
+    assert captured["exists_during_run"] is True
+    assert "image: repo/image:latest" in captured["content"]
+    assert "- NODE_ID=plugin-a" in captured["content"]
+    assert "- IN_JSON_STREAM_ID=stream-1" in captured["content"]
+    assert not compose_file.exists()


### PR DESCRIPTION
## Summary

This PR implements **Issue #17** by adding a real backend `pytest` suite for the deploy planner and local runtime helpers, plus the small cleanup required to make the planner reliably importable under test.

The new coverage focuses on the current FastAPI backend deploy path and verifies deterministic planning behavior without depending on live Docker side effects during test execution.

## What changed

| Area | Change |
| --- | --- |
| Backend tests | Added `backend/tests/test_deployment_planner.py` with coverage for deterministic deploy planning, DAG cycle rejection, unknown edge endpoints, stream validation, stream inference, env-var planning, and mocked env injection behavior. |
| Planner cleanup | Removed the duplicate broken helper definition at the end of `backend/deployment.py` so the module stays importable and testable. |
| Test config | Added `pytest` to backend dev dependencies and configured pytest discovery in `backend/pyproject.toml`. |
| Docs | Updated `backend/README.md` with repeatable instructions for running the backend test suite safely. |

## Validation

I ran the backend pytest suite from `backend/` after installing the listed dependencies:

```bash
python3.11 -m pytest -q
```

The result was:

```text
8 passed in 0.23s
```

## Review notes

I also ran an independent review pass on the complete patch after capturing the full diff, including the new test file. That review reported **no blocking issues** and marked the patch as ready to merge, with only optional follow-up suggestions around additional fan-out and stream-shape cases.

## Issue linkage

Closes #17
