### PR TITLE
Add server inventory, allocation planning, and Corelink health monitoring

### DIFF
--- a/backend/allocator.py
+++ b/backend/allocator.py
@@ -1,0 +1,70 @@
+"""Workflow allocation: decide where plugin nodes should run."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from corelink_health import CorelinkStatus, HealthReport
+from inventory import ManagedServer, get_available_servers
+
+
+@dataclass
+class AllocationDecision:
+    node_id: str
+    server_id: Optional[str]
+    strategy: str  # "managed", "local", "deferred"
+    reason: str
+
+
+def allocate_nodes(
+    queued_plugins: List[str],
+    node_requirements: Dict[str, dict],
+    corelink_health: HealthReport,
+) -> List[AllocationDecision]:
+    """Decide placement for each queued plugin node.
+
+    Strategies:
+      - "deferred": Corelink is unreachable, cannot safely place nodes
+      - "managed": Assigned to a managed server from inventory
+      - "local": No managed capacity available, fall back to local Docker
+    """
+    decisions: List[AllocationDecision] = []
+
+    if corelink_health.status == CorelinkStatus.UNREACHABLE:
+        for node_id in queued_plugins:
+            decisions.append(
+                AllocationDecision(
+                    node_id=node_id,
+                    server_id=None,
+                    strategy="deferred",
+                    reason="corelink_unreachable",
+                )
+            )
+        return decisions
+
+    for node_id in queued_plugins:
+        reqs = node_requirements.get(node_id, {})
+        labels = reqs.get("labels", [])
+
+        available = get_available_servers(required_labels=labels if labels else None)
+
+        if available:
+            server = available[0]  # Least loaded
+            decisions.append(
+                AllocationDecision(
+                    node_id=node_id,
+                    server_id=server.id,
+                    strategy="managed",
+                    reason=f"assigned to {server.hostname} (load: {server.current_load:.0%})",
+                )
+            )
+        else:
+            decisions.append(
+                AllocationDecision(
+                    node_id=node_id,
+                    server_id=None,
+                    strategy="local",
+                    reason="no_managed_capacity_available",
+                )
+            )
+
+    return decisions

--- a/backend/config/server_inventory.json
+++ b/backend/config/server_inventory.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "local-dev",
+    "hostname": "localhost",
+    "capacity": {"cpu_cores": 8, "memory_gb": 16, "gpu": null},
+    "labels": ["local", "dev"],
+    "current_load": 0.0,
+    "status": "healthy",
+    "running_nodes": []
+  }
+]

--- a/backend/corelink_health.py
+++ b/backend/corelink_health.py
@@ -1,0 +1,69 @@
+"""Corelink server health monitoring."""
+
+import asyncio
+import os
+import ssl
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+try:
+    import websockets
+
+    _HAS_WEBSOCKETS = True
+except ImportError:
+    websockets = None  # type: ignore[assignment]
+    _HAS_WEBSOCKETS = False
+
+
+class CorelinkStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNREACHABLE = "unreachable"
+    UNCONFIGURED = "unconfigured"
+
+
+@dataclass
+class HealthReport:
+    status: CorelinkStatus
+    latency_ms: Optional[float] = None
+    error: Optional[str] = None
+
+
+async def check_corelink_health(timeout: float = 5.0) -> HealthReport:
+    """Probe Corelink server via WSS handshake.
+
+    Returns a HealthReport indicating whether the server is reachable
+    and how long the connection took.
+    """
+    host = os.getenv("CORELINK_HOST")
+    port = os.getenv("CORELINK_PORT", "20012")
+
+    if not host:
+        return HealthReport(status=CorelinkStatus.UNCONFIGURED)
+
+    if not _HAS_WEBSOCKETS:
+        return HealthReport(
+            status=CorelinkStatus.UNREACHABLE,
+            error="websockets package not installed",
+        )
+
+    uri = f"wss://{host}:{port}"
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    try:
+        start = time.monotonic()
+        async with websockets.connect(uri, ssl=ssl_ctx, open_timeout=timeout):
+            latency = (time.monotonic() - start) * 1000
+            if latency > 2000:
+                return HealthReport(
+                    status=CorelinkStatus.DEGRADED, latency_ms=latency
+                )
+            return HealthReport(status=CorelinkStatus.HEALTHY, latency_ms=latency)
+    except asyncio.TimeoutError:
+        return HealthReport(status=CorelinkStatus.UNREACHABLE, error="timeout")
+    except Exception as e:
+        return HealthReport(status=CorelinkStatus.UNREACHABLE, error=str(e))

--- a/backend/inventory.py
+++ b/backend/inventory.py
@@ -1,0 +1,62 @@
+"""Managed server inventory for workflow allocation."""
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+
+class ServerStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    OFFLINE = "offline"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ManagedServer:
+    id: str
+    hostname: str
+    capacity: dict
+    labels: List[str] = field(default_factory=list)
+    current_load: float = 0.0
+    status: str = "unknown"
+    running_nodes: List[str] = field(default_factory=list)
+
+    @property
+    def server_status(self) -> ServerStatus:
+        try:
+            return ServerStatus(self.status)
+        except ValueError:
+            return ServerStatus.UNKNOWN
+
+
+INVENTORY_PATH = Path(__file__).parent / "config" / "server_inventory.json"
+
+
+def load_inventory(path: Optional[Path] = None) -> List[ManagedServer]:
+    """Load server inventory from JSON config file."""
+    inventory_path = path or INVENTORY_PATH
+    if not inventory_path.exists():
+        return []
+    data = json.loads(inventory_path.read_text())
+    return [ManagedServer(**s) for s in data]
+
+
+def get_available_servers(
+    required_labels: Optional[List[str]] = None,
+    path: Optional[Path] = None,
+) -> List[ManagedServer]:
+    """Return servers that are healthy/unknown and match label requirements."""
+    servers = load_inventory(path)
+    available = [
+        s
+        for s in servers
+        if s.server_status in (ServerStatus.HEALTHY, ServerStatus.UNKNOWN)
+    ]
+    if required_labels:
+        available = [
+            s for s in available if all(label in s.labels for label in required_labels)
+        ]
+    return sorted(available, key=lambda s: s.current_load)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 
 from fastapi import FastAPI, HTTPException, UploadFile
 
 from allowlist import check_workflow_images
+from allocator import allocate_nodes
+from corelink_health import check_corelink_health
 from deployment import deploy
 from executor import execute_dag
+from inventory import load_inventory
 from plugin_validation import ValidationResult, registry_login, validate_plugin_upload
 from workflow_types import DeployWorkflow
 
@@ -85,3 +89,38 @@ async def upload_plugin(file: UploadFile) -> ValidationResult:
     if not result.valid:
         raise HTTPException(status_code=422, detail=result.errors)
     return result
+
+
+@app.get("/health/corelink")
+async def corelink_health():
+    """Check Corelink server health."""
+    report = await check_corelink_health()
+    return {"status": report.status.value, "latency_ms": report.latency_ms, "error": report.error}
+
+
+@app.get("/inventory")
+async def list_inventory():
+    """List managed servers."""
+    servers = load_inventory()
+    return [asdict(s) for s in servers]
+
+
+@app.post("/deploy/plan")
+async def deploy_with_allocation(payload: DeployWorkflow, inject_env: bool = False):
+    """Plan deployment with allocation decisions."""
+    try:
+        result = deploy(payload, inject_env=inject_env)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    health = await check_corelink_health()
+    node_requirements = {node.id: node.data.get("requirements", {}) for node in payload.nodes}
+    allocation = allocate_nodes(result["queued_plugins"], node_requirements, health)
+
+    result["allocation"] = [asdict(d) for d in allocation]
+    result["corelink_health"] = {
+        "status": health.status.value,
+        "latency_ms": health.latency_ms,
+        "error": health.error,
+    }
+    return {"message": "Deploy plan with allocation generated", **result}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["colorama==0.4.6", "pytest==8.4.1"]
+dev = ["colorama==0.4.6", "pytest==8.4.1", "pytest-asyncio==1.3.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Dev/test-only dependencies for backend scripts (not production runtime)
 colorama==0.4.6
 pytest==8.4.1
+pytest-asyncio==1.3.0

--- a/backend/tests/test_allocator.py
+++ b/backend/tests/test_allocator.py
@@ -1,0 +1,155 @@
+"""Tests for workflow allocation planner."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from allocator import AllocationDecision, allocate_nodes
+from corelink_health import CorelinkStatus, HealthReport
+
+
+@pytest.fixture
+def healthy_corelink() -> HealthReport:
+    return HealthReport(status=CorelinkStatus.HEALTHY, latency_ms=50.0)
+
+
+@pytest.fixture
+def unreachable_corelink() -> HealthReport:
+    return HealthReport(status=CorelinkStatus.UNREACHABLE, error="timeout")
+
+
+@pytest.fixture
+def unconfigured_corelink() -> HealthReport:
+    return HealthReport(status=CorelinkStatus.UNCONFIGURED)
+
+
+@pytest.fixture
+def inventory_with_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    data = [
+        {
+            "id": "server-1",
+            "hostname": "gpu-box",
+            "capacity": {"cpu_cores": 16, "memory_gb": 64, "gpu": "a100"},
+            "labels": ["gpu", "prod"],
+            "current_load": 0.2,
+            "status": "healthy",
+            "running_nodes": [],
+        },
+        {
+            "id": "server-2",
+            "hostname": "cpu-box",
+            "capacity": {"cpu_cores": 8, "memory_gb": 16, "gpu": None},
+            "labels": ["cpu", "dev"],
+            "current_load": 0.5,
+            "status": "healthy",
+            "running_nodes": [],
+        },
+    ]
+    path = tmp_path / "inventory.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr("inventory.INVENTORY_PATH", path)
+    return path
+
+
+@pytest.fixture
+def empty_inventory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "inventory.json"
+    path.write_text("[]")
+    monkeypatch.setattr("inventory.INVENTORY_PATH", path)
+    return path
+
+
+def test_allocate_defers_when_corelink_unreachable(
+    unreachable_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-a", "plugin-b"],
+        node_requirements={},
+        corelink_health=unreachable_corelink,
+    )
+    assert len(decisions) == 2
+    assert all(d.strategy == "deferred" for d in decisions)
+    assert all(d.reason == "corelink_unreachable" for d in decisions)
+    assert all(d.server_id is None for d in decisions)
+
+
+def test_allocate_managed_when_servers_available(
+    healthy_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-a"],
+        node_requirements={"plugin-a": {}},
+        corelink_health=healthy_corelink,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].strategy == "managed"
+    assert decisions[0].server_id == "server-1"  # Least loaded
+    assert "gpu-box" in decisions[0].reason
+
+
+def test_allocate_with_label_filter(
+    healthy_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-gpu"],
+        node_requirements={"plugin-gpu": {"labels": ["gpu"]}},
+        corelink_health=healthy_corelink,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].strategy == "managed"
+    assert decisions[0].server_id == "server-1"
+
+
+def test_allocate_local_when_no_matching_servers(
+    healthy_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-special"],
+        node_requirements={"plugin-special": {"labels": ["nonexistent"]}},
+        corelink_health=healthy_corelink,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].strategy == "local"
+    assert decisions[0].server_id is None
+    assert "no_managed_capacity" in decisions[0].reason
+
+
+def test_allocate_local_when_inventory_empty(
+    healthy_corelink: HealthReport, empty_inventory: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-a"],
+        node_requirements={},
+        corelink_health=healthy_corelink,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].strategy == "local"
+
+
+def test_allocate_with_unconfigured_corelink_still_allocates(
+    unconfigured_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    """Unconfigured != unreachable. Still allocate if servers are available."""
+    decisions = allocate_nodes(
+        queued_plugins=["plugin-a"],
+        node_requirements={},
+        corelink_health=unconfigured_corelink,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].strategy == "managed"
+
+
+def test_allocate_multiple_plugins(
+    healthy_corelink: HealthReport, inventory_with_servers: Path
+) -> None:
+    decisions = allocate_nodes(
+        queued_plugins=["p1", "p2", "p3"],
+        node_requirements={},
+        corelink_health=healthy_corelink,
+    )
+    assert len(decisions) == 3
+    assert all(d.strategy == "managed" for d in decisions)

--- a/backend/tests/test_corelink_health.py
+++ b/backend/tests/test_corelink_health.py
@@ -1,0 +1,96 @@
+"""Tests for Corelink health monitoring."""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from corelink_health import CorelinkStatus, HealthReport, check_corelink_health
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_when_no_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORELINK_HOST", raising=False)
+    report = await check_corelink_health()
+    assert report.status == CorelinkStatus.UNCONFIGURED
+    assert report.latency_ms is None
+
+
+@pytest.mark.asyncio
+async def test_healthy_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+
+    import corelink_health
+
+    monkeypatch.setattr(corelink_health, "_HAS_WEBSOCKETS", True)
+
+    # Mock websockets.connect as an async context manager
+    mock_ws = AsyncMock()
+    mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+    mock_ws.__aexit__ = AsyncMock(return_value=False)
+
+    mock_websockets = MagicMock()
+    mock_websockets.connect.return_value = mock_ws
+    monkeypatch.setattr(corelink_health, "websockets", mock_websockets)
+
+    report = await check_corelink_health()
+
+    assert report.status == CorelinkStatus.HEALTHY
+    assert report.latency_ms is not None
+
+
+@pytest.mark.asyncio
+async def test_unreachable_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORELINK_HOST", "unreachable-host")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+
+    import corelink_health
+
+    monkeypatch.setattr(corelink_health, "_HAS_WEBSOCKETS", True)
+
+    mock_websockets = MagicMock()
+    mock_websockets.connect.side_effect = asyncio.TimeoutError()
+    monkeypatch.setattr(corelink_health, "websockets", mock_websockets)
+
+    report = await check_corelink_health()
+
+    assert report.status == CorelinkStatus.UNREACHABLE
+    assert report.error == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_on_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORELINK_HOST", "bad-host")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+
+    import corelink_health
+
+    monkeypatch.setattr(corelink_health, "_HAS_WEBSOCKETS", True)
+
+    mock_websockets = MagicMock()
+    mock_websockets.connect.side_effect = ConnectionRefusedError("refused")
+    monkeypatch.setattr(corelink_health, "websockets", mock_websockets)
+
+    report = await check_corelink_health()
+
+    assert report.status == CorelinkStatus.UNREACHABLE
+    assert "refused" in report.error
+
+
+@pytest.mark.asyncio
+async def test_websockets_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+
+    import corelink_health
+
+    monkeypatch.setattr(corelink_health, "_HAS_WEBSOCKETS", False)
+
+    report = await check_corelink_health()
+
+    assert report.status == CorelinkStatus.UNREACHABLE
+    assert "websockets" in report.error

--- a/backend/tests/test_inventory.py
+++ b/backend/tests/test_inventory.py
@@ -1,0 +1,97 @@
+"""Tests for server inventory management."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from inventory import ManagedServer, ServerStatus, get_available_servers, load_inventory
+
+
+@pytest.fixture
+def inventory_file(tmp_path: Path) -> Path:
+    data = [
+        {
+            "id": "server-1",
+            "hostname": "gpu-box-1",
+            "capacity": {"cpu_cores": 16, "memory_gb": 64, "gpu": "nvidia-a100"},
+            "labels": ["gpu", "high-memory"],
+            "current_load": 0.3,
+            "status": "healthy",
+            "running_nodes": ["node-x"],
+        },
+        {
+            "id": "server-2",
+            "hostname": "cpu-box-1",
+            "capacity": {"cpu_cores": 8, "memory_gb": 16, "gpu": None},
+            "labels": ["cpu", "dev"],
+            "current_load": 0.7,
+            "status": "healthy",
+            "running_nodes": [],
+        },
+        {
+            "id": "server-3",
+            "hostname": "offline-box",
+            "capacity": {"cpu_cores": 4, "memory_gb": 8, "gpu": None},
+            "labels": ["cpu"],
+            "current_load": 0.0,
+            "status": "offline",
+            "running_nodes": [],
+        },
+    ]
+    path = tmp_path / "inventory.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_load_inventory(inventory_file: Path) -> None:
+    servers = load_inventory(inventory_file)
+    assert len(servers) == 3
+    assert servers[0].id == "server-1"
+    assert servers[0].hostname == "gpu-box-1"
+    assert servers[0].capacity["gpu"] == "nvidia-a100"
+
+
+def test_load_inventory_missing_file(tmp_path: Path) -> None:
+    servers = load_inventory(tmp_path / "nonexistent.json")
+    assert servers == []
+
+
+def test_get_available_servers_excludes_offline(inventory_file: Path) -> None:
+    available = get_available_servers(path=inventory_file)
+    assert len(available) == 2
+    assert all(s.id != "server-3" for s in available)
+
+
+def test_get_available_servers_sorted_by_load(inventory_file: Path) -> None:
+    available = get_available_servers(path=inventory_file)
+    assert available[0].id == "server-1"  # 0.3 load
+    assert available[1].id == "server-2"  # 0.7 load
+
+
+def test_get_available_servers_filter_by_labels(inventory_file: Path) -> None:
+    available = get_available_servers(required_labels=["gpu"], path=inventory_file)
+    assert len(available) == 1
+    assert available[0].id == "server-1"
+
+
+def test_get_available_servers_no_match(inventory_file: Path) -> None:
+    available = get_available_servers(
+        required_labels=["nonexistent-label"], path=inventory_file
+    )
+    assert available == []
+
+
+def test_server_status_property() -> None:
+    server = ManagedServer(
+        id="test", hostname="h", capacity={}, status="healthy"
+    )
+    assert server.server_status == ServerStatus.HEALTHY
+
+    server_unknown = ManagedServer(
+        id="test", hostname="h", capacity={}, status="invalid_value"
+    )
+    assert server_unknown.server_status == ServerStatus.UNKNOWN


### PR DESCRIPTION
## Summary
Closes #22 (also consolidates #23).

Adds a managed server inventory, workflow allocation planner, and Corelink health monitoring so the backend can make intelligent placement decisions for plugin nodes.

## Changes
- **`backend/inventory.py`** — Server inventory model loaded from `config/server_inventory.json`. Supports label filtering and load-based sorting.
- **`backend/corelink_health.py`** — Async WSS health probe for Corelink server. Reports healthy/degraded/unreachable/unconfigured.
- **`backend/allocator.py`** — Allocation planner that assigns nodes to managed servers, falls back to local Docker, or defers when Corelink is unreachable.
- **`backend/main.py`** — Three new endpoints:
  - `GET /health/corelink` — Check Corelink server status
  - `GET /inventory` — List managed servers
  - `POST /deploy/plan` — Deploy plan with allocation decisions
- **19 new tests** (40 total pass)

## Test plan
- [x] `pytest tests/test_inventory.py` — 7 tests pass
- [x] `pytest tests/test_corelink_health.py` — 5 tests pass
- [x] `pytest tests/test_allocator.py` — 7 tests pass
- [x] Full suite (`pytest tests/`) — 40 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)