### PR TITLE
Add executor abstraction for pluggable container runtimes

### DIFF
--- a/backend/executors/__init__.py
+++ b/backend/executors/__init__.py
@@ -1,0 +1,40 @@
+"""Executor factory — resolves the active executor from config/env."""
+
+import os
+
+from .base import ContainerSpec, ContainerStatus, Executor
+from .local import LocalDockerExecutor
+
+__all__ = ["ContainerSpec", "ContainerStatus", "Executor", "get_executor"]
+
+
+def get_executor(strategy: str | None = None) -> Executor:
+    """Get an executor instance based on strategy or EXECUTOR_BACKEND env var.
+
+    Args:
+        strategy: "local" or "ecs". Defaults to EXECUTOR_BACKEND env var or "local".
+
+    Returns:
+        An Executor instance for the requested backend.
+
+    Raises:
+        ValueError: If the strategy is not recognized.
+    """
+    strategy = strategy or os.getenv("EXECUTOR_BACKEND", "local")
+
+    if strategy == "local":
+        return LocalDockerExecutor()
+    elif strategy == "ecs":
+        from .ecs import ECSExecutor
+
+        return ECSExecutor(
+            cluster=os.getenv("ECS_CLUSTER"),
+            region=os.getenv("AWS_REGION"),
+            subnet=os.getenv("ECS_SUBNET"),
+            security_group=os.getenv("ECS_SECURITY_GROUP"),
+        )
+    else:
+        raise ValueError(
+            f"Unknown executor strategy: '{strategy}'. "
+            f"Supported: 'local', 'ecs'"
+        )

--- a/backend/executors/base.py
+++ b/backend/executors/base.py
@@ -1,0 +1,63 @@
+"""Abstract executor protocol for container runtimes."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class ContainerSpec:
+    """Specification for a container to be started."""
+
+    node_id: str
+    image: str
+    env_vars: Dict[str, str] = field(default_factory=dict)
+    network: Optional[str] = None
+    cpu: Optional[float] = None  # vCPUs
+    memory_mb: Optional[int] = None
+    gpu: Optional[str] = None  # GPU type identifier
+    ports: Dict[int, int] = field(default_factory=dict)  # container:host
+
+
+@dataclass
+class ContainerStatus:
+    """Status of a managed container."""
+
+    node_id: str
+    container_id: str
+    status: str  # "running", "stopped", "failed", "pending"
+    host: Optional[str] = None
+    error: Optional[str] = None
+
+
+class Executor(ABC):
+    """Base executor interface for container runtimes.
+
+    Implementations handle the lifecycle of containers on a specific
+    backend (local Docker, ECS, Kubernetes, etc.).
+    """
+
+    @abstractmethod
+    async def start(self, spec: ContainerSpec) -> ContainerStatus:
+        """Start a container from spec. Returns status."""
+        ...
+
+    @abstractmethod
+    async def stop(self, container_id: str) -> bool:
+        """Stop a running container. Returns True on success."""
+        ...
+
+    @abstractmethod
+    async def status(self, container_id: str) -> ContainerStatus:
+        """Get current container status."""
+        ...
+
+    @abstractmethod
+    async def logs(self, container_id: str, tail: int = 100) -> str:
+        """Get container logs (stdout + stderr)."""
+        ...
+
+    @abstractmethod
+    async def health_check(self) -> bool:
+        """Check if the executor backend is reachable and operational."""
+        ...

--- a/backend/executors/ecs.py
+++ b/backend/executors/ecs.py
@@ -1,0 +1,59 @@
+"""AWS ECS executor (stub for future implementation).
+
+This executor will use boto3 to:
+- Register task definitions from ContainerSpec
+- Run tasks on a specified ECS cluster
+- Monitor task status via describe_tasks
+- Stream logs from CloudWatch Logs
+
+Required environment variables (future):
+  AWS_REGION        - AWS region for ECS cluster
+  ECS_CLUSTER       - ECS cluster name or ARN
+  ECS_SUBNET        - Subnet for awsvpc networking
+  ECS_SECURITY_GROUP - Security group for tasks
+  TASK_ROLE_ARN     - IAM role for task containers
+  EXECUTION_ROLE_ARN - IAM role for ECS agent
+"""
+
+from typing import Optional
+
+from .base import ContainerSpec, ContainerStatus, Executor
+
+
+class ECSExecutor(Executor):
+    """AWS ECS Fargate executor (not yet implemented)."""
+
+    def __init__(
+        self,
+        cluster: Optional[str] = None,
+        region: Optional[str] = None,
+        subnet: Optional[str] = None,
+        security_group: Optional[str] = None,
+    ):
+        self.cluster = cluster
+        self.region = region
+        self.subnet = subnet
+        self.security_group = security_group
+
+    async def start(self, spec: ContainerSpec) -> ContainerStatus:
+        """Register task definition and run task on ECS."""
+        raise NotImplementedError(
+            "ECS executor not yet implemented. "
+            "See docs/executor-abstraction.md for the planned approach."
+        )
+
+    async def stop(self, container_id: str) -> bool:
+        """Stop an ECS task."""
+        raise NotImplementedError("ECS executor not yet implemented.")
+
+    async def status(self, container_id: str) -> ContainerStatus:
+        """Get ECS task status via describe_tasks."""
+        raise NotImplementedError("ECS executor not yet implemented.")
+
+    async def logs(self, container_id: str, tail: int = 100) -> str:
+        """Get logs from CloudWatch Logs."""
+        raise NotImplementedError("ECS executor not yet implemented.")
+
+    async def health_check(self) -> bool:
+        """Check if ECS cluster is reachable via describe_clusters."""
+        raise NotImplementedError("ECS executor not yet implemented.")

--- a/backend/executors/local.py
+++ b/backend/executors/local.py
@@ -1,0 +1,126 @@
+"""Local Docker executor implementation."""
+
+import subprocess
+from typing import Optional
+
+from .base import ContainerSpec, ContainerStatus, Executor
+
+
+class LocalDockerExecutor(Executor):
+    """Executor that runs containers on the local Docker daemon."""
+
+    async def start(self, spec: ContainerSpec) -> ContainerStatus:
+        """Start a container locally via docker run."""
+        container_name = f"orch-{spec.node_id[:12]}"
+        cmd = ["docker", "run", "-d", "--name", container_name]
+
+        if spec.network:
+            cmd.extend(["--network", spec.network])
+        if spec.cpu:
+            cmd.extend(["--cpus", str(spec.cpu)])
+        if spec.memory_mb:
+            cmd.extend(["--memory", f"{spec.memory_mb}m"])
+        for container_port, host_port in spec.ports.items():
+            cmd.extend(["-p", f"{host_port}:{container_port}"])
+        for key, value in spec.env_vars.items():
+            cmd.extend(["-e", f"{key}={value}"])
+
+        cmd.append(spec.image)
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60
+            )
+        except subprocess.TimeoutExpired:
+            return ContainerStatus(
+                node_id=spec.node_id,
+                container_id="",
+                status="failed",
+                error="docker run timed out after 60s",
+            )
+
+        if result.returncode == 0:
+            container_id = result.stdout.strip()
+            return ContainerStatus(
+                node_id=spec.node_id,
+                container_id=container_id,
+                status="running",
+                host="localhost",
+            )
+
+        return ContainerStatus(
+            node_id=spec.node_id,
+            container_id="",
+            status="failed",
+            error=result.stderr.strip(),
+        )
+
+    async def stop(self, container_id: str) -> bool:
+        """Stop a local container."""
+        try:
+            result = subprocess.run(
+                ["docker", "stop", container_id],
+                capture_output=True,
+                timeout=30,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
+
+    async def status(self, container_id: str) -> ContainerStatus:
+        """Get status of a local container via docker inspect."""
+        try:
+            result = subprocess.run(
+                [
+                    "docker", "inspect",
+                    "--format", "{{.State.Status}}",
+                    container_id,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            return ContainerStatus(
+                node_id="", container_id=container_id, status="unknown"
+            )
+
+        if result.returncode == 0:
+            return ContainerStatus(
+                node_id="",
+                container_id=container_id,
+                status=result.stdout.strip(),
+                host="localhost",
+            )
+
+        return ContainerStatus(
+            node_id="",
+            container_id=container_id,
+            status="unknown",
+            error=result.stderr.strip(),
+        )
+
+    async def logs(self, container_id: str, tail: int = 100) -> str:
+        """Get logs from a local container."""
+        try:
+            result = subprocess.run(
+                ["docker", "logs", "--tail", str(tail), container_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.stdout + result.stderr
+        except subprocess.TimeoutExpired:
+            return ""
+
+    async def health_check(self) -> bool:
+        """Check if local Docker daemon is reachable."""
+        try:
+            result = subprocess.run(
+                ["docker", "info"],
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from allocator import allocate_nodes
 from corelink_health import check_corelink_health
 from deployment import deploy
 from executor import execute_dag
+from executors import ContainerSpec, get_executor
 from inventory import load_inventory
 from plugin_validation import ValidationResult, registry_login, validate_plugin_upload
 from workflow_types import DeployWorkflow
@@ -124,3 +125,47 @@ async def deploy_with_allocation(payload: DeployWorkflow, inject_env: bool = Fal
         "error": health.error,
     }
     return {"message": "Deploy plan with allocation generated", **result}
+
+
+@app.post("/deploy/execute/v2")
+async def deploy_and_execute_v2(
+    payload: DeployWorkflow, executor: str = "local", inject_env: bool = True
+):
+    """Plan deployment and execute containers via the pluggable executor abstraction."""
+    try:
+        plan = deploy(payload, inject_env=inject_env)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    ex = get_executor(executor)
+
+    if not await ex.health_check():
+        raise HTTPException(
+            status_code=503,
+            detail=f"Executor '{executor}' is not available",
+        )
+
+    node_map = {node.id: node for node in payload.nodes}
+    results = []
+
+    for node_id in plan["queued_plugins"]:
+        node = node_map[node_id]
+        image = node.runtime or node.data.get("runtime") or node.data.get("containerImage")
+        if not image:
+            results.append(
+                asdict(
+                    ContainerSpec(node_id=node_id, image=""),
+                )
+                | {"status": "skipped", "reason": "no_runtime_image"}
+            )
+            continue
+
+        spec = ContainerSpec(
+            node_id=node_id,
+            image=image,
+            env_vars=plan.get("env_plan", {}).get(node_id, {}),
+        )
+        status = await ex.start(spec)
+        results.append(asdict(status))
+
+    return {"message": "Deploy executed", "plan": plan, "execution": results}

--- a/backend/tests/test_executors.py
+++ b/backend/tests/test_executors.py
@@ -1,0 +1,221 @@
+"""Tests for the executor abstraction layer."""
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from executors import ContainerSpec, ContainerStatus, get_executor
+from executors.base import Executor
+from executors.local import LocalDockerExecutor
+
+
+class TestGetExecutor:
+    def test_returns_local_by_default(self) -> None:
+        ex = get_executor("local")
+        assert isinstance(ex, LocalDockerExecutor)
+
+    def test_returns_local_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXECUTOR_BACKEND", "local")
+        ex = get_executor()
+        assert isinstance(ex, LocalDockerExecutor)
+
+    def test_returns_ecs(self) -> None:
+        from executors.ecs import ECSExecutor
+
+        ex = get_executor("ecs")
+        assert isinstance(ex, ECSExecutor)
+
+    def test_raises_on_unknown(self) -> None:
+        with pytest.raises(ValueError, match="Unknown executor strategy"):
+            get_executor("kubernetes")
+
+
+class TestLocalDockerExecutor:
+    @pytest.fixture
+    def executor(self) -> LocalDockerExecutor:
+        return LocalDockerExecutor()
+
+    @pytest.mark.asyncio
+    async def test_start_success(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="abc123def456\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        spec = ContainerSpec(
+            node_id="plugin-1",
+            image="python:3.12-slim",
+            env_vars={"NODE_ID": "plugin-1", "FOO": "bar"},
+        )
+        status = await executor.start(spec)
+
+        assert status.status == "running"
+        assert status.container_id == "abc123def456"
+        assert status.host == "localhost"
+        assert status.node_id == "plugin-1"
+
+    @pytest.mark.asyncio
+    async def test_start_failure(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="Error: image not found"
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        spec = ContainerSpec(node_id="plugin-1", image="bad:image", env_vars={})
+        status = await executor.start(spec)
+
+        assert status.status == "failed"
+        assert "image not found" in status.error
+        assert status.container_id == ""
+
+    @pytest.mark.asyncio
+    async def test_start_timeout(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 60)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        spec = ContainerSpec(node_id="plugin-1", image="slow:image", env_vars={})
+        status = await executor.start(spec)
+
+        assert status.status == "failed"
+        assert "timed out" in status.error
+
+    @pytest.mark.asyncio
+    async def test_start_with_resource_limits(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return SimpleNamespace(returncode=0, stdout="container-id\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        spec = ContainerSpec(
+            node_id="plugin-1",
+            image="python:3.12-slim",
+            env_vars={},
+            cpu=2.0,
+            memory_mb=1024,
+            network="test-net",
+            ports={3000: 8080},
+        )
+        await executor.start(spec)
+
+        assert "--cpus" in captured_cmd
+        assert "2.0" in captured_cmd
+        assert "--memory" in captured_cmd
+        assert "1024m" in captured_cmd
+        assert "--network" in captured_cmd
+        assert "test-net" in captured_cmd
+        assert "-p" in captured_cmd
+        assert "8080:3000" in captured_cmd
+
+    @pytest.mark.asyncio
+    async def test_stop_success(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert await executor.stop("abc123") is True
+
+    @pytest.mark.asyncio
+    async def test_stop_failure(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=1)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert await executor.stop("nonexistent") is False
+
+    @pytest.mark.asyncio
+    async def test_status_running(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="running\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = await executor.status("abc123")
+        assert result.status == "running"
+        assert result.host == "localhost"
+
+    @pytest.mark.asyncio
+    async def test_logs(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(
+                returncode=0, stdout="Starting server...\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        logs = await executor.logs("abc123", tail=50)
+        assert "Starting server" in logs
+
+    @pytest.mark.asyncio
+    async def test_health_check_docker_available(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert await executor.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_docker_unavailable(
+        self, executor: LocalDockerExecutor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=1)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert await executor.health_check() is False
+
+
+class TestECSExecutor:
+    @pytest.mark.asyncio
+    async def test_start_not_implemented(self) -> None:
+        from executors.ecs import ECSExecutor
+
+        ex = ECSExecutor()
+        with pytest.raises(NotImplementedError):
+            await ex.start(
+                ContainerSpec(node_id="n1", image="python:3.12", env_vars={})
+            )
+
+    @pytest.mark.asyncio
+    async def test_stop_not_implemented(self) -> None:
+        from executors.ecs import ECSExecutor
+
+        ex = ECSExecutor()
+        with pytest.raises(NotImplementedError):
+            await ex.stop("task-id")
+
+    @pytest.mark.asyncio
+    async def test_health_check_not_implemented(self) -> None:
+        from executors.ecs import ECSExecutor
+
+        ex = ECSExecutor()
+        with pytest.raises(NotImplementedError):
+            await ex.health_check()


### PR DESCRIPTION
## Summary
Closes #27.

Adds a pluggable executor abstraction so the orchestration layer can target different container runtimes (local Docker today, ECS/K8s in the future) without rewriting the deploy model.

## Changes
- **`backend/executors/base.py`** — Abstract `Executor` protocol with `ContainerSpec` and `ContainerStatus` dataclasses
- **`backend/executors/local.py`** — `LocalDockerExecutor` implementing start/stop/status/logs/health_check via subprocess
- **`backend/executors/ecs.py`** — ECS executor stub with documented approach for future implementation
- **`backend/executors/__init__.py`** — Factory (`get_executor(strategy)`) resolving from env var or parameter
- **`backend/main.py`** — New `POST /deploy/execute` endpoint that plans + executes via the selected executor
- **17 new tests** covering factory, local executor, and ECS stub (38 total pass)

## Architecture
```
get_executor("local") → LocalDockerExecutor
get_executor("ecs")   → ECSExecutor (stub)

POST /deploy/execute?executor=local
  1. deploy(workflow) → plan
  2. get_executor(executor) → ex
  3. ex.health_check()
  4. For each queued plugin: ex.start(ContainerSpec(...))
  5. Return plan + execution results
```

## Test plan
- [x] `pytest tests/test_executors.py` — 17 tests pass
- [x] Full suite (`pytest tests/`) — 38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)