### PR TITLE
Add frontend CI pipeline and expand backend CI to all tests

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -41,12 +41,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+          pip install python-multipart
 
-      - name: "[backend] Deployment planner"
-        run: python -m pytest tests/test_deployment_planner.py -v
-
-      - name: "[backend] Plugin upload validation"
-        run: python -m pytest tests/test_plugin_validation.py -v
+      - name: Run all backend tests
+        run: python -m pytest tests/ -v
 
   # ── Job 2: Reference plugin unit tests ────────────────────────────────────
   reference-plugin:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,66 @@
+name: Frontend CI
+
+"on":
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
## Summary
Adds a frontend CI pipeline and expands backend CI to run all test files.

Closes #44

## Changes
- **New `.github/workflows/frontend-ci.yml`** — Runs on PRs touching `frontend/**`:
  - **Lint & Type Check** job: `npm run lint` + `npx tsc --noEmit`
  - **Unit Tests** job: `npm run test` (vitest)
  - Node 20, npm ci with cache
- **Updated `.github/workflows/backend-pytest.yml`**:
  - Replaced 2 cherry-picked test file steps with `pytest tests/ -v` (runs all 7 test files, 51 tests)
  - Added `python-multipart` to deps (required by `test_allowlist_executor.py` which imports `main.py`)

## Before / After

**Backend CI before:** 2 test files (16 tests)
**Backend CI after:** 7 test files (51 tests)

**Frontend CI before:** none
**Frontend CI after:** lint + type-check + 11 vitest tests

## Test plan
- [x] Backend tests pass locally (51/51)
- [x] Frontend vitest passes locally (11/11)
- [ ] Verify workflows trigger on this PR
- [ ] Verify frontend lint/type-check jobs complete (pre-existing type errors in stale `_old.tsx` files may need to be addressed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)