### PR TITLE
feat: Docker Hub browser + Dockerized test containers (closes #33, #34, #35, #36)

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -5,7 +5,6 @@ name: Test Suite
     paths:
       - "backend/**"
       - "plugins/**"
-      - "docker_images/**"
       - ".github/workflows/backend-pytest.yml"
   push:
     branches:
@@ -13,7 +12,6 @@ name: Test Suite
     paths:
       - "backend/**"
       - "plugins/**"
-      - "docker_images/**"
       - ".github/workflows/backend-pytest.yml"
   workflow_dispatch:
 
@@ -49,18 +47,6 @@ jobs:
 
       - name: "[backend] Plugin upload validation"
         run: python -m pytest tests/test_plugin_validation.py -v
-
-      - name: "[backend] Docker Hub proxy"
-        run: python -m pytest tests/test_dockerhub.py -v
-
-      - name: "[backend] Test-sender smoke tests"
-        run: python -m pytest tests/test_docker_sender.py -v
-
-      - name: "[backend] Test-receiver smoke tests"
-        run: python -m pytest tests/test_docker_receiver.py -v
-
-      - name: "[backend] Test-plugin smoke tests"
-        run: python -m pytest tests/test_docker_plugin.py -v
 
   # ── Job 2: Reference plugin unit tests ────────────────────────────────────
   reference-plugin:
@@ -129,106 +115,3 @@ jobs:
           sleep 3
           curl --retry 5 --retry-delay 1 --fail http://localhost:8080/health
           docker rm -f ref-plugin-ci
-
-  # ── Job 4: test-sender Docker build ───────────────────────────────────────
-  test-sender-docker-build:
-    name: Test Sender Docker Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build test-sender image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker_images/test_sender
-          push: false
-          load: true
-          tags: test-sender:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test — /health endpoint
-        run: |
-          docker run -d --name test-sender-ci -p 3000:3000 \
-            -e NODE_ID=sender-ci \
-            -e OUT_JSON_WORKSPACE=test-ws \
-            test-sender:ci
-          sleep 5
-          curl --retry 8 --retry-delay 1 --fail http://localhost:3000/health
-          curl --retry 3 --retry-delay 1 --fail http://localhost:3000/status
-          docker rm -f test-sender-ci
-
-  # ── Job 5: test-receiver Docker build ─────────────────────────────────────
-  test-receiver-docker-build:
-    name: Test Receiver Docker Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build test-receiver image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker_images/test_receiver
-          push: false
-          load: true
-          tags: test-receiver:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test — /health endpoint
-        run: |
-          docker run -d --name test-receiver-ci -p 3001:3000 \
-            -e NODE_ID=recv-ci \
-            -e IN_JSON_WORKSPACE=test-ws \
-            test-receiver:ci
-          sleep 5
-          curl --retry 8 --retry-delay 1 --fail http://localhost:3001/health
-          curl --retry 3 --retry-delay 1 --fail http://localhost:3001/status
-          docker rm -f test-receiver-ci
-
-  # ── Job 6: test-plugin Docker build ───────────────────────────────────────
-  test-plugin-docker-build:
-    name: Test Plugin Docker Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build test-plugin image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker_images/test_plugin
-          push: false
-          load: true
-          tags: test-plugin:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test — /health endpoint
-        run: |
-          docker run -d --name test-plugin-ci -p 3002:3000 \
-            -e NODE_ID=plugin-ci \
-            -e NODE_TYPE=plugin \
-            -e IN_JSON_WORKSPACE=in-ws \
-            -e IN_JSON_STREAM_ID=stream-in \
-            -e OUT_JSON_WORKSPACE=out-ws \
-            -e OUT_JSON_STREAM_ID=stream-out \
-            test-plugin:ci
-          sleep 5
-          curl --retry 8 --retry-delay 1 --fail http://localhost:3002/health
-          curl --retry 3 --retry-delay 1 --fail http://localhost:3002/status
-          docker rm -f test-plugin-ci

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -5,6 +5,7 @@ name: Test Suite
     paths:
       - "backend/**"
       - "plugins/**"
+      - "docker_images/**"
       - ".github/workflows/backend-pytest.yml"
   push:
     branches:
@@ -12,6 +13,7 @@ name: Test Suite
     paths:
       - "backend/**"
       - "plugins/**"
+      - "docker_images/**"
       - ".github/workflows/backend-pytest.yml"
   workflow_dispatch:
 
@@ -47,6 +49,18 @@ jobs:
 
       - name: "[backend] Plugin upload validation"
         run: python -m pytest tests/test_plugin_validation.py -v
+
+      - name: "[backend] Docker Hub proxy"
+        run: python -m pytest tests/test_dockerhub.py -v
+
+      - name: "[backend] Test-sender smoke tests"
+        run: python -m pytest tests/test_docker_sender.py -v
+
+      - name: "[backend] Test-receiver smoke tests"
+        run: python -m pytest tests/test_docker_receiver.py -v
+
+      - name: "[backend] Test-plugin smoke tests"
+        run: python -m pytest tests/test_docker_plugin.py -v
 
   # ── Job 2: Reference plugin unit tests ────────────────────────────────────
   reference-plugin:
@@ -115,3 +129,106 @@ jobs:
           sleep 3
           curl --retry 5 --retry-delay 1 --fail http://localhost:8080/health
           docker rm -f ref-plugin-ci
+
+  # ── Job 4: test-sender Docker build ───────────────────────────────────────
+  test-sender-docker-build:
+    name: Test Sender Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test-sender image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker_images/test_sender
+          push: false
+          load: true
+          tags: test-sender:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — /health endpoint
+        run: |
+          docker run -d --name test-sender-ci -p 3000:3000 \
+            -e NODE_ID=sender-ci \
+            -e OUT_JSON_WORKSPACE=test-ws \
+            test-sender:ci
+          sleep 5
+          curl --retry 8 --retry-delay 1 --fail http://localhost:3000/health
+          curl --retry 3 --retry-delay 1 --fail http://localhost:3000/status
+          docker rm -f test-sender-ci
+
+  # ── Job 5: test-receiver Docker build ─────────────────────────────────────
+  test-receiver-docker-build:
+    name: Test Receiver Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test-receiver image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker_images/test_receiver
+          push: false
+          load: true
+          tags: test-receiver:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — /health endpoint
+        run: |
+          docker run -d --name test-receiver-ci -p 3001:3000 \
+            -e NODE_ID=recv-ci \
+            -e IN_JSON_WORKSPACE=test-ws \
+            test-receiver:ci
+          sleep 5
+          curl --retry 8 --retry-delay 1 --fail http://localhost:3001/health
+          curl --retry 3 --retry-delay 1 --fail http://localhost:3001/status
+          docker rm -f test-receiver-ci
+
+  # ── Job 6: test-plugin Docker build ───────────────────────────────────────
+  test-plugin-docker-build:
+    name: Test Plugin Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test-plugin image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker_images/test_plugin
+          push: false
+          load: true
+          tags: test-plugin:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — /health endpoint
+        run: |
+          docker run -d --name test-plugin-ci -p 3002:3000 \
+            -e NODE_ID=plugin-ci \
+            -e NODE_TYPE=plugin \
+            -e IN_JSON_WORKSPACE=in-ws \
+            -e IN_JSON_STREAM_ID=stream-in \
+            -e OUT_JSON_WORKSPACE=out-ws \
+            -e OUT_JSON_STREAM_ID=stream-out \
+            test-plugin:ci
+          sleep 5
+          curl --retry 8 --retry-delay 1 --fail http://localhost:3002/health
+          curl --retry 3 --retry-delay 1 --fail http://localhost:3002/status
+          docker rm -f test-plugin-ci

--- a/backend/config/allowed_images.json
+++ b/backend/config/allowed_images.json
@@ -1,1 +1,14 @@
-{}
+{
+  "test-sender:latest": {
+    "approved": true,
+    "notes": "Dockerized test sender for DAG integration tests (issue #34)"
+  },
+  "test-receiver:latest": {
+    "approved": true,
+    "notes": "Dockerized test receiver for DAG integration tests (issue #35)"
+  },
+  "test-plugin:latest": {
+    "approved": true,
+    "notes": "Dockerized test plugin for DAG integration tests (issue #36)"
+  }
+}

--- a/backend/dockerhub.py
+++ b/backend/dockerhub.py
@@ -1,0 +1,76 @@
+"""Docker Hub search proxy.
+
+Proxies requests to the public Docker Hub v2 API, avoiding CORS issues from
+the browser, and annotates each result with its allowlist approval status so
+the frontend can show an approval badge without a separate round-trip.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from allowlist import is_approved
+
+DOCKERHUB_SEARCH_URL = "https://hub.docker.com/v2/search/repositories/"
+DOCKERHUB_TAGS_URL = "https://hub.docker.com/v2/repositories/{namespace}/{repo}/tags/"
+
+# Reasonable timeout for Docker Hub API calls (seconds)
+_TIMEOUT = 10.0
+
+
+async def search_images(query: str, page: int = 1, page_size: int = 20) -> dict:
+    """Search Docker Hub and annotate results with allowlist approval status.
+
+    Parameters
+    ----------
+    query:
+        Free-text search term forwarded to Docker Hub.
+    page:
+        1-based page number.
+    page_size:
+        Number of results per page (max 100 per Docker Hub limits).
+
+    Returns
+    -------
+    dict
+        Raw Docker Hub search response with an extra ``approved`` boolean
+        field injected into every result entry.
+    """
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(
+            DOCKERHUB_SEARCH_URL,
+            params={"query": query, "page": page, "page_size": page_size},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    for result in data.get("results", []):
+        repo_name: str = result.get("repo_name", "")
+        result["approved"] = is_approved(repo_name)
+
+    return data
+
+
+async def get_image_tags(namespace: str, repo: str, page: int = 1) -> dict:
+    """Return paginated tags for a Docker Hub image.
+
+    Parameters
+    ----------
+    namespace:
+        Docker Hub namespace (e.g. ``library`` for official images, or a
+        username/org).
+    repo:
+        Repository name within the namespace.
+    page:
+        1-based page number.
+
+    Returns
+    -------
+    dict
+        Raw Docker Hub tags response.
+    """
+    url = DOCKERHUB_TAGS_URL.format(namespace=namespace, repo=repo)
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(url, params={"page": page, "page_size": 25})
+        resp.raise_for_status()
+        return resp.json()

--- a/backend/dockerhub.py
+++ b/backend/dockerhub.py
@@ -46,7 +46,12 @@ async def search_images(query: str, page: int = 1, page_size: int = 20) -> dict:
 
     for result in data.get("results", []):
         repo_name: str = result.get("repo_name", "")
-        result["approved"] = is_approved(repo_name)
+        # Docker Hub returns bare names ("nginx") or "library/nginx" for official images.
+        # Normalize to the form used in the allowlist ("nginx:latest").
+        normalized = repo_name.removeprefix("library/")
+        if ":" not in normalized:
+            normalized = f"{normalized}:latest"
+        result["approved"] = is_approved(normalized)
 
     return data
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from dataclasses import asdict
 from fastapi import FastAPI, HTTPException, UploadFile
 
 from allowlist import check_workflow_images
+from dockerhub import get_image_tags, search_images
 from allocator import allocate_nodes
 from corelink_health import check_corelink_health
 from deployment import deploy
@@ -90,6 +91,24 @@ async def upload_plugin(file: UploadFile) -> ValidationResult:
     if not result.valid:
         raise HTTPException(status_code=422, detail=result.errors)
     return result
+
+
+@app.get("/dockerhub/search")
+async def dockerhub_search(query: str, page: int = 1, page_size: int = 20):
+    """Search Docker Hub and annotate results with allowlist approval status."""
+    try:
+        return await search_images(query, page=page, page_size=page_size)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"Docker Hub search failed: {exc}") from exc
+
+
+@app.get("/dockerhub/tags/{namespace}/{repo}")
+async def dockerhub_tags(namespace: str, repo: str, page: int = 1):
+    """Return paginated tags for a Docker Hub image."""
+    try:
+        return await get_image_tags(namespace, repo, page=page)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"Docker Hub tags fetch failed: {exc}") from exc
 
 
 @app.get("/health/corelink")

--- a/backend/tests/test_docker_plugin.py
+++ b/backend/tests/test_docker_plugin.py
@@ -2,8 +2,7 @@
 
 These tests import the plugin's FastAPI app directly (without Docker) to
 validate the HTTP contract, env-var parsing, and the transform function in a
-fast, dependency-free way.  Full Docker build / run smoke tests are handled in
-CI via the ``test-plugin-docker-build`` workflow job.
+fast, dependency-free way.
 """
 
 from __future__ import annotations
@@ -22,18 +21,23 @@ from fastapi.testclient import TestClient
 
 def _load_plugin_app(env: dict[str, str] | None = None):
     """Load the plugin app module with optional env overrides."""
-    for k, v in (env or {}).items():
-        os.environ[k] = v
+    _original_env = os.environ.copy()
+    try:
+        for k, v in (env or {}).items():
+            os.environ[k] = v
 
-    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    plugin_path = os.path.join(repo_root, "docker_images", "test_plugin", "main.py")
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        plugin_path = os.path.join(repo_root, "docker_images", "test_plugin", "main.py")
 
-    spec = importlib.util.spec_from_file_location("test_plugin_main", plugin_path)
-    assert spec is not None
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
-    return module
+        spec = importlib.util.spec_from_file_location("test_plugin_main", plugin_path)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        return module
+    finally:
+        os.environ.clear()
+        os.environ.update(_original_env)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_docker_plugin.py
+++ b/backend/tests/test_docker_plugin.py
@@ -1,0 +1,119 @@
+"""Smoke tests for the test-plugin Docker image.
+
+These tests import the plugin's FastAPI app directly (without Docker) to
+validate the HTTP contract, env-var parsing, and the transform function in a
+fast, dependency-free way.  Full Docker build / run smoke tests are handled in
+CI via the ``test-plugin-docker-build`` workflow job.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_plugin_app(env: dict[str, str] | None = None):
+    """Load the plugin app module with optional env overrides."""
+    for k, v in (env or {}).items():
+        os.environ[k] = v
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    plugin_path = os.path.join(repo_root, "docker_images", "test_plugin", "main.py")
+
+    spec = importlib.util.spec_from_file_location("test_plugin_main", plugin_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_health_endpoint_returns_ok() -> None:
+    """GET /health returns {"ok": true}."""
+    module = _load_plugin_app({"NODE_ID": "plugin-test", "CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_status_endpoint_returns_node_id() -> None:
+    """GET /status includes the configured NODE_ID."""
+    module = _load_plugin_app({"NODE_ID": "plugin-smoke", "CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["node_id"] == "plugin-smoke"
+
+
+def test_status_endpoint_includes_in_and_out_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /status reflects both IN_* and OUT_* env vars."""
+    monkeypatch.setenv("IN_JSON_WORKSPACE", "in-ws")
+    monkeypatch.setenv("IN_JSON_STREAM_ID", "stream-in")
+    monkeypatch.setenv("OUT_JSON_WORKSPACE", "out-ws")
+    monkeypatch.setenv("OUT_JSON_STREAM_ID", "stream-out")
+    monkeypatch.setenv("CORELINK_HOST", "")
+
+    module = _load_plugin_app()
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "JSON" in data["in_streams"]
+    assert "JSON" in data["out_streams"]
+    assert data["in_streams"]["JSON"]["workspace"] == "in-ws"
+    assert data["out_streams"]["JSON"]["workspace"] == "out-ws"
+
+
+def test_transform_adds_processed_fields() -> None:
+    """_transform adds processed_by and processed_at to a JSON payload."""
+    module = _load_plugin_app({"NODE_ID": "plugin-transform"})
+    original = {"value": 42, "label": "test"}
+    result_bytes = module._transform(json.dumps(original).encode())
+    result = json.loads(result_bytes)
+    assert result["value"] == 42
+    assert result["label"] == "test"
+    assert result["processed_by"] == "plugin-transform"
+    assert isinstance(result["processed_at"], int)
+
+
+def test_transform_handles_non_json_input() -> None:
+    """_transform wraps non-JSON data in a raw envelope."""
+    module = _load_plugin_app({"NODE_ID": "plugin-transform"})
+    result_bytes = module._transform(b"not json at all")
+    result = json.loads(result_bytes)
+    assert "raw" in result
+    assert result["processed_by"] == "plugin-transform"
+
+
+def test_status_initial_message_counts_are_zero() -> None:
+    """GET /status shows zero message counts before any data flows."""
+    module = _load_plugin_app({"CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["messages_received"] == 0
+    assert data["messages_sent"] == 0
+
+
+def test_test_plugin_is_on_allowlist() -> None:
+    """test-plugin:latest must be on the allowlist for executor acceptance."""
+    import allowlist  # noqa: PLC0415
+
+    assert allowlist.is_approved("test-plugin:latest"), (
+        "test-plugin:latest is not in backend/config/allowed_images.json — "
+        "add it so the executor can start the container."
+    )

--- a/backend/tests/test_docker_receiver.py
+++ b/backend/tests/test_docker_receiver.py
@@ -1,0 +1,81 @@
+"""Smoke tests for the test-receiver Docker image.
+
+These tests import the receiver's FastAPI app directly (without Docker) to
+validate the HTTP contract and env-var parsing logic in a fast, dependency-free
+way.  Full Docker build / run smoke tests are handled in CI via the
+``test-receiver-docker-build`` workflow job.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_receiver_app(env: dict[str, str] | None = None):
+    """Load the receiver app module with optional env overrides."""
+    for k, v in (env or {}).items():
+        os.environ[k] = v
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    receiver_path = os.path.join(repo_root, "docker_images", "test_receiver", "main.py")
+
+    spec = importlib.util.spec_from_file_location("test_receiver_main", receiver_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_health_endpoint_returns_ok() -> None:
+    """GET /health returns {"ok": true}."""
+    module = _load_receiver_app({"NODE_ID": "recv-test", "CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_status_endpoint_returns_node_id() -> None:
+    """GET /status includes the configured NODE_ID."""
+    module = _load_receiver_app({"NODE_ID": "recv-smoke", "CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["node_id"] == "recv-smoke"
+
+
+def test_status_endpoint_includes_in_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /status reflects IN_* env vars in in_streams."""
+    monkeypatch.setenv("IN_JSON_WORKSPACE", "recv-ws")
+    monkeypatch.setenv("IN_JSON_STREAM_ID", "stream-recv")
+    monkeypatch.setenv("CORELINK_HOST", "")
+
+    module = _load_receiver_app()
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "JSON" in data["in_streams"]
+    assert data["in_streams"]["JSON"]["workspace"] == "recv-ws"
+
+
+def test_status_initial_messages_received_is_zero() -> None:
+    """GET /status shows messages_received == 0 before any data arrives."""
+    module = _load_receiver_app({"CORELINK_HOST": ""})
+    client = TestClient(module.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["messages_received"] == 0

--- a/backend/tests/test_docker_receiver.py
+++ b/backend/tests/test_docker_receiver.py
@@ -2,8 +2,7 @@
 
 These tests import the receiver's FastAPI app directly (without Docker) to
 validate the HTTP contract and env-var parsing logic in a fast, dependency-free
-way.  Full Docker build / run smoke tests are handled in CI via the
-``test-receiver-docker-build`` workflow job.
+way.
 """
 
 from __future__ import annotations
@@ -21,18 +20,23 @@ from fastapi.testclient import TestClient
 
 def _load_receiver_app(env: dict[str, str] | None = None):
     """Load the receiver app module with optional env overrides."""
-    for k, v in (env or {}).items():
-        os.environ[k] = v
+    _original_env = os.environ.copy()
+    try:
+        for k, v in (env or {}).items():
+            os.environ[k] = v
 
-    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    receiver_path = os.path.join(repo_root, "docker_images", "test_receiver", "main.py")
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        receiver_path = os.path.join(repo_root, "docker_images", "test_receiver", "main.py")
 
-    spec = importlib.util.spec_from_file_location("test_receiver_main", receiver_path)
-    assert spec is not None
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
-    return module
+        spec = importlib.util.spec_from_file_location("test_receiver_main", receiver_path)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        return module
+    finally:
+        os.environ.clear()
+        os.environ.update(_original_env)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_docker_sender.py
+++ b/backend/tests/test_docker_sender.py
@@ -1,0 +1,101 @@
+"""Smoke tests for the test-sender Docker image.
+
+These tests import the sender's FastAPI app directly (without Docker) to
+validate the HTTP contract and env-var parsing logic in a fast, dependency-free
+way.  Full Docker build / run smoke tests are handled in CI via the
+``test-sender-docker-build`` workflow job.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(env: dict[str, str] | None = None) -> TestClient:
+    """Import the sender app with a custom environment and return a TestClient.
+
+    We reload the module each time so that module-level env reads pick up the
+    monkeypatched values.
+    """
+    import importlib
+    import sys
+
+    # Patch os.environ before import
+    for k, v in (env or {}).items():
+        os.environ[k] = v
+
+    # Force re-import so module-level constants are re-evaluated
+    if "docker_images.test_sender.main" in sys.modules:
+        del sys.modules["docker_images.test_sender.main"]
+
+    # Add docker_images to path if needed
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    sender_dir = os.path.join(repo_root, "docker_images", "test_sender")
+    if sender_dir not in sys.path:
+        sys.path.insert(0, sender_dir)
+
+    if "main" in sys.modules:
+        # Avoid collision with backend/main.py
+        del sys.modules["main"]
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "test_sender_main",
+        os.path.join(sender_dir, "main.py"),
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+    return TestClient(module.app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_health_endpoint_returns_ok() -> None:
+    """GET /health returns {"ok": true}."""
+    client = _make_client({"NODE_ID": "sender-test", "CORELINK_HOST": ""})
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_status_endpoint_returns_node_id() -> None:
+    """GET /status includes the configured NODE_ID."""
+    client = _make_client({"NODE_ID": "sender-smoke", "CORELINK_HOST": ""})
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["node_id"] == "sender-smoke"
+
+
+def test_status_endpoint_includes_out_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /status reflects OUT_* env vars in out_streams."""
+    monkeypatch.setenv("OUT_JSON_WORKSPACE", "test-ws")
+    monkeypatch.setenv("OUT_JSON_STREAM_ID", "stream-1")
+    monkeypatch.setenv("CORELINK_HOST", "")
+
+    client = _make_client()
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "JSON" in data["out_streams"]
+    assert data["out_streams"]["JSON"]["workspace"] == "test-ws"
+
+
+def test_status_initial_messages_sent_is_zero() -> None:
+    """GET /status shows messages_sent == 0 before any publish loop runs."""
+    client = _make_client({"CORELINK_HOST": ""})
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["messages_sent"] == 0

--- a/backend/tests/test_docker_sender.py
+++ b/backend/tests/test_docker_sender.py
@@ -2,8 +2,7 @@
 
 These tests import the sender's FastAPI app directly (without Docker) to
 validate the HTTP contract and env-var parsing logic in a fast, dependency-free
-way.  Full Docker build / run smoke tests are handled in CI via the
-``test-sender-docker-build`` workflow job.
+way.
 """
 
 from __future__ import annotations
@@ -24,38 +23,42 @@ def _make_client(env: dict[str, str] | None = None) -> TestClient:
     We reload the module each time so that module-level env reads pick up the
     monkeypatched values.
     """
-    import importlib
+    import importlib.util
     import sys
 
-    # Patch os.environ before import
-    for k, v in (env or {}).items():
-        os.environ[k] = v
+    _original_env = os.environ.copy()
+    try:
+        # Patch os.environ before import
+        for k, v in (env or {}).items():
+            os.environ[k] = v
 
-    # Force re-import so module-level constants are re-evaluated
-    if "docker_images.test_sender.main" in sys.modules:
-        del sys.modules["docker_images.test_sender.main"]
+        # Force re-import so module-level constants are re-evaluated
+        if "docker_images.test_sender.main" in sys.modules:
+            del sys.modules["docker_images.test_sender.main"]
 
-    # Add docker_images to path if needed
-    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    sender_dir = os.path.join(repo_root, "docker_images", "test_sender")
-    if sender_dir not in sys.path:
-        sys.path.insert(0, sender_dir)
+        # Add docker_images to path if needed
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        sender_dir = os.path.join(repo_root, "docker_images", "test_sender")
+        if sender_dir not in sys.path:
+            sys.path.insert(0, sender_dir)
 
-    if "main" in sys.modules:
-        # Avoid collision with backend/main.py
-        del sys.modules["main"]
+        if "main" in sys.modules:
+            # Avoid collision with backend/main.py
+            del sys.modules["main"]
 
-    import importlib.util
-    spec = importlib.util.spec_from_file_location(
-        "test_sender_main",
-        os.path.join(sender_dir, "main.py"),
-    )
-    assert spec is not None
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
+        spec = importlib.util.spec_from_file_location(
+            "test_sender_main",
+            os.path.join(sender_dir, "main.py"),
+        )
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
 
-    return TestClient(module.app)
+        return TestClient(module.app)
+    finally:
+        os.environ.clear()
+        os.environ.update(_original_env)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dockerhub.py
+++ b/backend/tests/test_dockerhub.py
@@ -1,0 +1,212 @@
+"""Tests for the Docker Hub search proxy (backend/dockerhub.py).
+
+All external HTTP calls are mocked so the suite runs without network access.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import allowlist
+import dockerhub
+import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_response(payload: dict, status_code: int = 200) -> MagicMock:
+    """Return a mock httpx.Response-like object."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = payload
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _write_allowlist(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# search_images unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_images_returns_annotated_results(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """search_images annotates results with allowlist approval status."""
+    allowlist_path = tmp_path / "config" / "allowed_images.json"
+    _write_allowlist(allowlist_path, {"nginx:latest": {"approved": True}})
+    monkeypatch.setattr(allowlist, "ALLOWLIST_PATH", allowlist_path)
+
+    fake_payload = {
+        "count": 2,
+        "results": [
+            {"repo_name": "nginx:latest", "description": "Official nginx"},
+            {"repo_name": "redis:latest", "description": "Official redis"},
+        ],
+    }
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_mock_response(fake_payload))
+
+    with patch("dockerhub.httpx.AsyncClient", return_value=mock_client):
+        result = await dockerhub.search_images("nginx")
+
+    assert result["count"] == 2
+    results = result["results"]
+    nginx_result = next(r for r in results if r["repo_name"] == "nginx:latest")
+    redis_result = next(r for r in results if r["repo_name"] == "redis:latest")
+    assert nginx_result["approved"] is True
+    assert redis_result["approved"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_images_passes_pagination_params(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """search_images forwards page and page_size to Docker Hub."""
+    allowlist_path = tmp_path / "config" / "allowed_images.json"
+    _write_allowlist(allowlist_path, {})
+    monkeypatch.setattr(allowlist, "ALLOWLIST_PATH", allowlist_path)
+
+    fake_payload = {"count": 0, "results": []}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_mock_response(fake_payload))
+
+    with patch("dockerhub.httpx.AsyncClient", return_value=mock_client):
+        await dockerhub.search_images("python", page=3, page_size=10)
+
+    call_kwargs = mock_client.get.call_args
+    params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+    assert params["page"] == 3
+    assert params["page_size"] == 10
+
+
+# ---------------------------------------------------------------------------
+# get_image_tags unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_image_tags_returns_tags() -> None:
+    """get_image_tags returns the raw Docker Hub tags payload."""
+    fake_payload = {
+        "count": 2,
+        "results": [
+            {"name": "latest", "full_size": 123456},
+            {"name": "1.25", "full_size": 123000},
+        ],
+    }
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_mock_response(fake_payload))
+
+    with patch("dockerhub.httpx.AsyncClient", return_value=mock_client):
+        result = await dockerhub.get_image_tags("library", "nginx")
+
+    assert result["count"] == 2
+    tag_names = [t["name"] for t in result["results"]]
+    assert "latest" in tag_names
+    assert "1.25" in tag_names
+
+
+@pytest.mark.asyncio
+async def test_get_image_tags_builds_correct_url() -> None:
+    """get_image_tags constructs the correct Docker Hub URL."""
+    fake_payload = {"count": 0, "results": []}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_mock_response(fake_payload))
+
+    with patch("dockerhub.httpx.AsyncClient", return_value=mock_client):
+        await dockerhub.get_image_tags("myorg", "myrepo")
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "myorg" in called_url
+    assert "myrepo" in called_url
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests (via FastAPI TestClient)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(main.app)
+
+
+def test_dockerhub_search_endpoint_returns_results(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """GET /dockerhub/search returns annotated results."""
+    allowlist_path = tmp_path / "config" / "allowed_images.json"
+    _write_allowlist(allowlist_path, {})
+    monkeypatch.setattr(allowlist, "ALLOWLIST_PATH", allowlist_path)
+
+    fake_payload = {
+        "count": 1,
+        "results": [{"repo_name": "alpine", "description": "Alpine Linux"}],
+    }
+
+    async def _mock_search(query: str, page: int = 1, page_size: int = 20) -> dict:
+        return {**fake_payload, "results": [{**fake_payload["results"][0], "approved": False}]}
+
+    monkeypatch.setattr(main, "search_images", _mock_search)
+
+    resp = client.get("/dockerhub/search", params={"query": "alpine"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["results"][0]["repo_name"] == "alpine"
+
+
+def test_dockerhub_search_endpoint_propagates_502_on_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /dockerhub/search returns 502 when Docker Hub is unreachable."""
+
+    async def _failing_search(*_args, **_kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main, "search_images", _failing_search)
+
+    resp = client.get("/dockerhub/search", params={"query": "alpine"})
+    assert resp.status_code == 502
+
+
+def test_dockerhub_tags_endpoint_returns_tags(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /dockerhub/tags/{namespace}/{repo} returns tag list."""
+    fake_payload = {"count": 1, "results": [{"name": "latest"}]}
+
+    async def _mock_tags(namespace: str, repo: str, page: int = 1) -> dict:
+        return fake_payload
+
+    monkeypatch.setattr(main, "get_image_tags", _mock_tags)
+
+    resp = client.get("/dockerhub/tags/library/nginx")
+    assert resp.status_code == 200
+    assert resp.json()["results"][0]["name"] == "latest"

--- a/backend/tests/test_dockerhub.py
+++ b/backend/tests/test_dockerhub.py
@@ -48,11 +48,13 @@ async def test_search_images_returns_annotated_results(
     _write_allowlist(allowlist_path, {"nginx:latest": {"approved": True}})
     monkeypatch.setattr(allowlist, "ALLOWLIST_PATH", allowlist_path)
 
+    # Real Docker Hub v2 search API returns bare repo names, no tags.
+    # Official images come back as "nginx" or "library/nginx", never "nginx:latest".
     fake_payload = {
         "count": 2,
         "results": [
-            {"repo_name": "nginx:latest", "description": "Official nginx"},
-            {"repo_name": "redis:latest", "description": "Official redis"},
+            {"repo_name": "nginx", "description": "Official nginx"},
+            {"repo_name": "redis", "description": "Official redis"},
         ],
     }
 
@@ -66,9 +68,11 @@ async def test_search_images_returns_annotated_results(
 
     assert result["count"] == 2
     results = result["results"]
-    nginx_result = next(r for r in results if r["repo_name"] == "nginx:latest")
-    redis_result = next(r for r in results if r["repo_name"] == "redis:latest")
+    nginx_result = next(r for r in results if r["repo_name"] == "nginx")
+    redis_result = next(r for r in results if r["repo_name"] == "redis")
+    # "nginx" normalises to "nginx:latest" which is in the allowlist above → approved
     assert nginx_result["approved"] is True
+    # "redis" normalises to "redis:latest" which is NOT in the allowlist → not approved
     assert redis_result["approved"] is False
 
 

--- a/docker_images/test_plugin/Dockerfile
+++ b/docker_images/test_plugin/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 3000
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s \
+  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker_images/test_plugin/README.md
+++ b/docker_images/test_plugin/README.md
@@ -1,0 +1,77 @@
+# test-plugin
+
+A Dockerized test plugin that receives data on input streams, applies a simple
+transform, and publishes the result to output streams — validating the full
+plugin lifecycle in orchestrator-driven DAG integration tests.
+
+## Transform
+
+For every inbound JSON message the plugin adds two fields:
+
+```json
+{
+  "...original fields...",
+  "processed_by": "<NODE_ID>",
+  "processed_at": 1713900000000
+}
+```
+
+Non-JSON payloads are wrapped in `{"raw": "..."}` before the fields are added.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NODE_ID` | `test-plugin` | Unique node identifier injected by the orchestrator |
+| `NODE_TYPE` | `plugin` | Node role (informational) |
+| `CORELINK_HOST` | _(empty)_ | Corelink server hostname |
+| `CORELINK_PORT` | `20010` | Corelink server port |
+| `CORELINK_USERNAME` | _(empty)_ | Corelink auth username |
+| `CORELINK_PASSWORD` | _(empty)_ | Corelink auth password |
+| `IN_<TYPE>_WORKSPACE` | _(empty)_ | Corelink workspace for input stream of `<TYPE>` |
+| `IN_<TYPE>_STREAM_ID` | _(empty)_ | Stream ID for input stream of `<TYPE>` |
+| `IN_<TYPE>_PROTOCOL` | `pubsub` | Protocol for input stream of `<TYPE>` |
+| `OUT_<TYPE>_WORKSPACE` | _(empty)_ | Corelink workspace for output stream of `<TYPE>` |
+| `OUT_<TYPE>_STREAM_ID` | _(empty)_ | Stream ID for output stream of `<TYPE>` |
+| `OUT_<TYPE>_PROTOCOL` | `pubsub` | Protocol for output stream of `<TYPE>` |
+
+When `CORELINK_HOST`, `CORELINK_USERNAME`, and `CORELINK_PASSWORD` are absent
+the container starts in **HTTP-only mode** — the Corelink loop is skipped but
+`/health` and `/status` remain available.
+
+## HTTP endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /health` | Liveness probe — returns `{"ok": true}` |
+| `GET /status` | Connection state, message counts, last I/O, and stream config |
+
+## Allowlist
+
+Add `test-plugin:latest` to `backend/config/allowed_images.json` so the
+executor accepts it:
+
+```json
+{
+  "test-plugin:latest": { "approved": true, "notes": "Integration test plugin" }
+}
+```
+
+## Quick start
+
+```bash
+docker build -t test-plugin .
+
+# HTTP-only smoke test (no Corelink required)
+docker run -d -p 3002:3000 \
+  -e NODE_ID=plugin-1 \
+  -e NODE_TYPE=plugin \
+  -e IN_JSON_WORKSPACE=test-ws \
+  -e IN_JSON_STREAM_ID=stream-in \
+  -e OUT_JSON_WORKSPACE=test-ws \
+  -e OUT_JSON_STREAM_ID=stream-out \
+  test-plugin
+
+curl http://localhost:3002/health
+curl http://localhost:3002/status
+```

--- a/docker_images/test_plugin/main.py
+++ b/docker_images/test_plugin/main.py
@@ -1,0 +1,229 @@
+"""Test plugin — receives, transforms, and publishes data via Corelink.
+
+Lifecycle
+---------
+1. On startup, reads orchestrator-injected env vars (NODE_ID, IN_*/OUT_* stream
+   creds, Corelink connection details) and starts a background Corelink loop.
+2. For every inbound message on any IN_* stream, applies a simple transform
+   (adds ``processed_by`` and ``processed_at`` fields) and publishes the result
+   to every OUT_* stream.
+3. If Corelink credentials are absent, the container starts in HTTP-only mode
+   and still exposes /health and /status — useful for smoke tests.
+
+HTTP endpoints
+--------------
+GET /health  →  {"ok": true}
+GET /status  →  connection state, message counts, and stream config
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI
+
+# ---------------------------------------------------------------------------
+# Configuration from orchestrator-injected env vars
+# ---------------------------------------------------------------------------
+
+NODE_ID: str = os.getenv("NODE_ID", "test-plugin")
+NODE_TYPE: str = os.getenv("NODE_TYPE", "plugin")
+
+CORELINK_HOST: str = os.getenv("CORELINK_HOST", "")
+CORELINK_PORT: int = int(os.getenv("CORELINK_PORT", "20010"))
+CORELINK_USERNAME: str = os.getenv("CORELINK_USERNAME", "")
+CORELINK_PASSWORD: str = os.getenv("CORELINK_PASSWORD", "")
+
+# ---------------------------------------------------------------------------
+# Stream env var parsing (same pattern as reference plugin)
+# ---------------------------------------------------------------------------
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    """Scan env for IN_/OUT_<TYPE>_WORKSPACE / _STREAM_ID / _PROTOCOL groups."""
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.getenv(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.getenv(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+# ---------------------------------------------------------------------------
+# Shared mutable state
+# ---------------------------------------------------------------------------
+
+_state: dict = {
+    "connected": False,
+    "messages_received": 0,
+    "messages_sent": 0,
+    "last_input": None,
+    "last_output": None,
+    "last_error": None,
+}
+
+# Corelink sender stream IDs (stream_type → corelink stream_id)
+_out_senders: dict[str, int] = {}
+
+
+# ---------------------------------------------------------------------------
+# Transform
+# ---------------------------------------------------------------------------
+
+
+def _transform(data: bytes) -> bytes:
+    """Add ``processed_by`` and ``processed_at`` fields to a JSON payload.
+
+    Falls back to wrapping non-JSON data in a ``{"raw": ...}`` envelope so the
+    plugin never drops messages.
+    """
+    try:
+        payload = json.loads(data.decode("utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001
+        payload = {"raw": data.decode("utf-8", errors="replace")}
+
+    payload["processed_by"] = NODE_ID
+    payload["processed_at"] = int(time.time() * 1000)
+    return json.dumps(payload).encode()
+
+
+# ---------------------------------------------------------------------------
+# Corelink callbacks
+# ---------------------------------------------------------------------------
+
+
+async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
+    """Called for every inbound message across all subscribed IN streams."""
+    _state["messages_received"] += 1
+    try:
+        _state["last_input"] = json.loads(data.decode("utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001
+        _state["last_input"] = {"raw_bytes": len(data)}
+
+    result = _transform(data)
+
+    try:
+        _state["last_output"] = json.loads(result.decode())
+    except Exception:  # noqa: BLE001
+        pass
+
+    for sid in _out_senders.values():
+        await _corelink_module.send(sid, result)  # type: ignore[name-defined]
+    _state["messages_sent"] += len(_out_senders)
+
+
+# We store the corelink module reference here so _on_data can call send().
+_corelink_module = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Corelink connection loop
+# ---------------------------------------------------------------------------
+
+
+async def _corelink_loop() -> None:
+    """Connect to Corelink, subscribe to IN streams, create OUT senders."""
+    global _corelink_module  # noqa: PLW0603
+
+    if not (CORELINK_HOST and CORELINK_USERNAME and CORELINK_PASSWORD):
+        print(f"[test-plugin] CORELINK_HOST/USERNAME/PASSWORD not set — HTTP-only mode")
+        return
+
+    try:
+        import corelink  # noqa: PLC0415
+
+        _corelink_module = corelink
+
+        await corelink.connect(CORELINK_USERNAME, CORELINK_PASSWORD, CORELINK_HOST, CORELINK_PORT)
+        print(f"[test-plugin] Connected to Corelink at {CORELINK_HOST}:{CORELINK_PORT}")
+        _state["connected"] = True
+
+        await corelink.set_data_callback(_on_data)
+
+        in_streams = _parse_stream_env("IN_")
+        for stream_type, cfg in in_streams.items():
+            stream_ids = [cfg["stream_id"]] if cfg["stream_id"] else []
+            await corelink.create_receiver(
+                workspace=cfg["workspace"],
+                protocol="tcp",
+                data_type=stream_type.lower(),
+                stream_ids=stream_ids,
+                alert=True,
+            )
+            print(f"[test-plugin] Receiver ready: {stream_type} @ {cfg['workspace']}")
+
+        out_streams = _parse_stream_env("OUT_")
+        for stream_type, cfg in out_streams.items():
+            sid = await corelink.create_sender(
+                workspace=cfg["workspace"],
+                protocol="tcp",
+                data_type=stream_type.lower(),
+            )
+            _out_senders[stream_type] = sid
+            print(f"[test-plugin] Sender ready: {stream_type} @ {cfg['workspace']} (stream_id={sid})")
+
+        # Stay alive — Corelink delivers data via callbacks
+        await asyncio.sleep(float("inf"))
+
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _state["last_error"] = str(exc)
+        print(f"[test-plugin] ERROR: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _log_startup()
+    task = asyncio.create_task(_corelink_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+def _log_startup() -> None:
+    print(f"[test-plugin] NODE_ID={NODE_ID} NODE_TYPE={NODE_TYPE}")
+    for k, v in os.environ.items():
+        if k.startswith("IN_") or k.startswith("OUT_"):
+            print(f"[test-plugin]   {k}={v}")
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/status")
+def status():
+    return {
+        **_state,
+        "node_id": NODE_ID,
+        "node_type": NODE_TYPE,
+        "in_streams": _parse_stream_env("IN_"),
+        "out_streams": _parse_stream_env("OUT_"),
+        "out_sender_ids": _out_senders,
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=3000)

--- a/docker_images/test_plugin/requirements.txt
+++ b/docker_images/test_plugin/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink

--- a/docker_images/test_receiver/Dockerfile
+++ b/docker_images/test_receiver/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 3000
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s \
+  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker_images/test_receiver/README.md
+++ b/docker_images/test_receiver/README.md
@@ -1,0 +1,46 @@
+# test-receiver
+
+A minimal Dockerized receiver used in backend-driven DAG integration tests.
+It subscribes to Corelink streams and collects messages, exposing counts and
+the last received payload via HTTP so tests can assert end-to-end delivery.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NODE_ID` | `test-receiver` | Unique node identifier injected by the orchestrator |
+| `NODE_TYPE` | `receiver` | Node role (informational) |
+| `CORELINK_HOST` | _(empty)_ | Corelink server hostname |
+| `CORELINK_PORT` | `20010` | Corelink server port |
+| `CORELINK_USERNAME` | _(empty)_ | Corelink auth username |
+| `CORELINK_PASSWORD` | _(empty)_ | Corelink auth password |
+| `IN_<TYPE>_WORKSPACE` | _(empty)_ | Corelink workspace for input stream of `<TYPE>` |
+| `IN_<TYPE>_STREAM_ID` | _(empty)_ | Stream ID for input stream of `<TYPE>` |
+| `IN_<TYPE>_PROTOCOL` | `pubsub` | Protocol for input stream of `<TYPE>` |
+
+When `CORELINK_HOST`, `CORELINK_USERNAME`, and `CORELINK_PASSWORD` are absent
+the container starts in **HTTP-only mode** — the subscribe loop is skipped but
+`/health` and `/status` remain available.
+
+## HTTP endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /health` | Liveness probe — returns `{"ok": true}` |
+| `GET /status` | Connection state, `messages_received`, `last_message`, and stream config |
+
+## Quick start
+
+```bash
+docker build -t test-receiver .
+
+# HTTP-only smoke test (no Corelink required)
+docker run -d -p 3001:3000 \
+  -e NODE_ID=recv-1 \
+  -e IN_JSON_WORKSPACE=test-ws \
+  -e IN_JSON_STREAM_ID=stream-1 \
+  test-receiver
+
+curl http://localhost:3001/health
+curl http://localhost:3001/status
+```

--- a/docker_images/test_receiver/main.py
+++ b/docker_images/test_receiver/main.py
@@ -1,0 +1,170 @@
+"""Test receiver — subscribes to Corelink streams using orchestrator env vars.
+
+Lifecycle
+---------
+1. On startup, reads orchestrator-injected env vars (NODE_ID, IN_* stream creds,
+   Corelink connection details) and starts a background subscribe loop.
+2. For every message received on any IN_* stream, increments ``messages_received``
+   and stores the decoded payload in ``last_message``.
+3. If Corelink credentials are absent, the container starts in HTTP-only mode
+   and still exposes /health and /status — useful for smoke tests.
+
+HTTP endpoints
+--------------
+GET /health  →  {"ok": true}
+GET /status  →  connection state, message count, last message, and stream config
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI
+
+# ---------------------------------------------------------------------------
+# Configuration from orchestrator-injected env vars
+# ---------------------------------------------------------------------------
+
+NODE_ID: str = os.getenv("NODE_ID", "test-receiver")
+NODE_TYPE: str = os.getenv("NODE_TYPE", "receiver")
+
+CORELINK_HOST: str = os.getenv("CORELINK_HOST", "")
+CORELINK_PORT: int = int(os.getenv("CORELINK_PORT", "20010"))
+CORELINK_USERNAME: str = os.getenv("CORELINK_USERNAME", "")
+CORELINK_PASSWORD: str = os.getenv("CORELINK_PASSWORD", "")
+
+# ---------------------------------------------------------------------------
+# Stream env var parsing (same pattern as reference plugin)
+# ---------------------------------------------------------------------------
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    """Scan env for IN_<TYPE>_WORKSPACE / _STREAM_ID / _PROTOCOL groups."""
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.getenv(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.getenv(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+# ---------------------------------------------------------------------------
+# Shared mutable state
+# ---------------------------------------------------------------------------
+
+_state: dict = {
+    "connected": False,
+    "messages_received": 0,
+    "last_message": None,
+    "last_error": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Corelink callbacks
+# ---------------------------------------------------------------------------
+
+
+async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
+    """Called for every inbound message across all subscribed IN streams."""
+    _state["messages_received"] += 1
+    try:
+        _state["last_message"] = json.loads(data.decode("utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001
+        _state["last_message"] = {"raw_bytes": len(data)}
+
+
+# ---------------------------------------------------------------------------
+# Subscribe loop
+# ---------------------------------------------------------------------------
+
+
+async def _subscribe_loop() -> None:
+    """Connect to Corelink and subscribe to all configured IN_* streams."""
+    if not (CORELINK_HOST and CORELINK_USERNAME and CORELINK_PASSWORD):
+        print(f"[test-receiver] CORELINK_HOST/USERNAME/PASSWORD not set — HTTP-only mode")
+        return
+
+    try:
+        import corelink  # noqa: PLC0415
+
+        await corelink.connect(CORELINK_USERNAME, CORELINK_PASSWORD, CORELINK_HOST, CORELINK_PORT)
+        print(f"[test-receiver] Connected to Corelink at {CORELINK_HOST}:{CORELINK_PORT}")
+        _state["connected"] = True
+
+        await corelink.set_data_callback(_on_data)
+
+        in_streams = _parse_stream_env("IN_")
+        for stream_type, cfg in in_streams.items():
+            stream_ids = [cfg["stream_id"]] if cfg["stream_id"] else []
+            await corelink.create_receiver(
+                workspace=cfg["workspace"],
+                protocol="tcp",
+                data_type=stream_type.lower(),
+                stream_ids=stream_ids,
+                alert=True,
+            )
+            print(f"[test-receiver] Receiver ready: {stream_type} @ {cfg['workspace']}")
+
+        # Stay alive — Corelink delivers data via callbacks
+        await asyncio.sleep(float("inf"))
+
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _state["last_error"] = str(exc)
+        print(f"[test-receiver] ERROR: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _log_startup()
+    task = asyncio.create_task(_subscribe_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+def _log_startup() -> None:
+    print(f"[test-receiver] NODE_ID={NODE_ID} NODE_TYPE={NODE_TYPE}")
+    for k, v in os.environ.items():
+        if k.startswith("IN_"):
+            print(f"[test-receiver]   {k}={v}")
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/status")
+def status():
+    return {
+        **_state,
+        "node_id": NODE_ID,
+        "node_type": NODE_TYPE,
+        "in_streams": _parse_stream_env("IN_"),
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=3000)

--- a/docker_images/test_receiver/requirements.txt
+++ b/docker_images/test_receiver/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink

--- a/docker_images/test_sender/Dockerfile
+++ b/docker_images/test_sender/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 3000
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s \
+  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker_images/test_sender/README.md
+++ b/docker_images/test_sender/README.md
@@ -1,0 +1,57 @@
+# test-sender
+
+A minimal Dockerized sender used in backend-driven DAG integration tests.
+It publishes configurable JSON messages to Corelink streams using
+orchestrator-injected environment variables.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NODE_ID` | `test-sender` | Unique node identifier injected by the orchestrator |
+| `NODE_TYPE` | `sender` | Node role (informational) |
+| `SEND_INTERVAL_MS` | `2000` | Milliseconds between published messages |
+| `CORELINK_HOST` | _(empty)_ | Corelink server hostname |
+| `CORELINK_PORT` | `20010` | Corelink server port |
+| `CORELINK_USERNAME` | _(empty)_ | Corelink auth username |
+| `CORELINK_PASSWORD` | _(empty)_ | Corelink auth password |
+| `OUT_<TYPE>_WORKSPACE` | _(empty)_ | Corelink workspace for output stream of `<TYPE>` |
+| `OUT_<TYPE>_STREAM_ID` | _(empty)_ | Stream ID for output stream of `<TYPE>` |
+| `OUT_<TYPE>_PROTOCOL` | `pubsub` | Protocol for output stream of `<TYPE>` |
+
+When `CORELINK_HOST`, `CORELINK_USERNAME`, and `CORELINK_PASSWORD` are absent
+the container starts in **HTTP-only mode** — the publish loop is skipped but
+`/health` and `/status` remain available.
+
+## HTTP endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /health` | Liveness probe — returns `{"ok": true}` |
+| `GET /status` | Connection state, message count, and stream config |
+
+## Published message format
+
+```json
+{
+  "node_id": "<NODE_ID>",
+  "seq": 42,
+  "ts": 1713900000000
+}
+```
+
+## Quick start
+
+```bash
+docker build -t test-sender .
+
+# HTTP-only smoke test (no Corelink required)
+docker run -d -p 3000:3000 \
+  -e NODE_ID=sender-1 \
+  -e OUT_JSON_WORKSPACE=test-ws \
+  -e OUT_JSON_STREAM_ID=stream-1 \
+  test-sender
+
+curl http://localhost:3000/health
+curl http://localhost:3000/status
+```

--- a/docker_images/test_sender/main.py
+++ b/docker_images/test_sender/main.py
@@ -1,0 +1,172 @@
+"""Test sender — publishes JSON messages to Corelink using orchestrator env vars.
+
+Lifecycle
+---------
+1. On startup, reads orchestrator-injected env vars (NODE_ID, OUT_* stream creds,
+   Corelink connection details) and starts a background publish loop.
+2. Every SEND_INTERVAL_MS milliseconds, publishes a JSON message containing
+   ``node_id``, a monotonically increasing ``seq`` counter, and a Unix timestamp
+   to every configured OUT_* stream.
+3. If Corelink credentials are absent, the container starts in HTTP-only mode
+   and still exposes /health and /status — useful for smoke tests.
+
+HTTP endpoints
+--------------
+GET /health  →  {"ok": true}
+GET /status  →  current connection state, message count, and stream config
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI
+
+# ---------------------------------------------------------------------------
+# Configuration from orchestrator-injected env vars
+# ---------------------------------------------------------------------------
+
+NODE_ID: str = os.getenv("NODE_ID", "test-sender")
+NODE_TYPE: str = os.getenv("NODE_TYPE", "sender")
+SEND_INTERVAL_MS: int = int(os.getenv("SEND_INTERVAL_MS", "2000"))
+
+CORELINK_HOST: str = os.getenv("CORELINK_HOST", "")
+CORELINK_PORT: int = int(os.getenv("CORELINK_PORT", "20010"))
+CORELINK_USERNAME: str = os.getenv("CORELINK_USERNAME", "")
+CORELINK_PASSWORD: str = os.getenv("CORELINK_PASSWORD", "")
+
+# ---------------------------------------------------------------------------
+# Stream env var parsing (same pattern as reference plugin)
+# ---------------------------------------------------------------------------
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    """Scan env for OUT_<TYPE>_WORKSPACE / _STREAM_ID / _PROTOCOL groups."""
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.getenv(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.getenv(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+# ---------------------------------------------------------------------------
+# Shared mutable state
+# ---------------------------------------------------------------------------
+
+_state: dict = {
+    "connected": False,
+    "messages_sent": 0,
+    "last_message": None,
+    "last_error": None,
+}
+
+# Corelink sender stream IDs (stream_type → corelink stream_id)
+_out_senders: dict[str, int] = {}
+
+
+# ---------------------------------------------------------------------------
+# Publish loop
+# ---------------------------------------------------------------------------
+
+
+async def _publish_loop() -> None:
+    """Connect to Corelink and publish messages at the configured interval."""
+    if not (CORELINK_HOST and CORELINK_USERNAME and CORELINK_PASSWORD):
+        print(f"[test-sender] CORELINK_HOST/USERNAME/PASSWORD not set — HTTP-only mode")
+        return
+
+    try:
+        import corelink  # noqa: PLC0415
+
+        await corelink.connect(CORELINK_USERNAME, CORELINK_PASSWORD, CORELINK_HOST, CORELINK_PORT)
+        print(f"[test-sender] Connected to Corelink at {CORELINK_HOST}:{CORELINK_PORT}")
+        _state["connected"] = True
+
+        out_streams = _parse_stream_env("OUT_")
+        for stream_type, cfg in out_streams.items():
+            sid = await corelink.create_sender(
+                workspace=cfg["workspace"],
+                protocol="tcp",
+                data_type=stream_type.lower(),
+            )
+            _out_senders[stream_type] = sid
+            print(f"[test-sender] Sender ready: {stream_type} @ {cfg['workspace']} (stream_id={sid})")
+
+        seq = 0
+        while True:
+            msg: dict = {
+                "node_id": NODE_ID,
+                "seq": seq,
+                "ts": int(time.time() * 1000),
+            }
+            payload = json.dumps(msg).encode()
+            for sid in _out_senders.values():
+                await corelink.send(sid, payload)
+
+            _state["messages_sent"] += 1
+            _state["last_message"] = msg
+            seq += 1
+            await asyncio.sleep(SEND_INTERVAL_MS / 1000)
+
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _state["last_error"] = str(exc)
+        print(f"[test-sender] ERROR: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _log_startup()
+    task = asyncio.create_task(_publish_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+def _log_startup() -> None:
+    print(f"[test-sender] NODE_ID={NODE_ID} NODE_TYPE={NODE_TYPE}")
+    for k, v in os.environ.items():
+        if k.startswith("OUT_"):
+            print(f"[test-sender]   {k}={v}")
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/status")
+def status():
+    return {
+        **_state,
+        "node_id": NODE_ID,
+        "node_type": NODE_TYPE,
+        "out_streams": _parse_stream_env("OUT_"),
+        "send_interval_ms": SEND_INTERVAL_MS,
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=3000)

--- a/docker_images/test_sender/requirements.txt
+++ b/docker_images/test_sender/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink

--- a/frontend/app/api/dockerhub/search/route.ts
+++ b/frontend/app/api/dockerhub/search/route.ts
@@ -3,8 +3,7 @@
  *
  * GET /api/dockerhub/search?query=<term>&page=<n>&page_size=<n>
  *
- * Forwards the request to the Python backend which handles CORS, rate-limiting
- * concerns, and allowlist annotation.
+ * Forwards the request to the Python backend which handles CORS and allowlist annotation.
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/frontend/app/api/dockerhub/search/route.ts
+++ b/frontend/app/api/dockerhub/search/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Next.js API route: proxy Docker Hub image search to the backend.
+ *
+ * GET /api/dockerhub/search?query=<term>&page=<n>&page_size=<n>
+ *
+ * Forwards the request to the Python backend which handles CORS, rate-limiting
+ * concerns, and allowlist annotation.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('query') ?? '';
+  const page = searchParams.get('page') ?? '1';
+  const pageSize = searchParams.get('page_size') ?? '20';
+
+  if (!query.trim()) {
+    return NextResponse.json({ count: 0, results: [] });
+  }
+
+  try {
+    const upstream = new URL(`${BACKEND_URL}/dockerhub/search`);
+    upstream.searchParams.set('query', query);
+    upstream.searchParams.set('page', page);
+    upstream.searchParams.set('page_size', pageSize);
+
+    const res = await fetch(upstream.toString(), { cache: 'no-store' });
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `Backend returned ${res.status}` },
+        { status: 502 },
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 502 },
+    );
+  }
+}

--- a/frontend/app/api/dockerhub/tags/[namespace]/[repo]/route.ts
+++ b/frontend/app/api/dockerhub/tags/[namespace]/[repo]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Next.js API route: proxy Docker Hub image tags to the backend.
+ *
+ * GET /api/dockerhub/tags/<namespace>/<repo>?page=<n>
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { namespace: string; repo: string } },
+) {
+  const { namespace, repo } = params;
+  const { searchParams } = new URL(request.url);
+  const page = searchParams.get('page') ?? '1';
+
+  try {
+    const upstream = new URL(
+      `${BACKEND_URL}/dockerhub/tags/${encodeURIComponent(namespace)}/${encodeURIComponent(repo)}`,
+    );
+    upstream.searchParams.set('page', page);
+
+    const res = await fetch(upstream.toString(), { cache: 'no-store' });
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `Backend returned ${res.status}` },
+        { status: 502 },
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 502 },
+    );
+  }
+}

--- a/frontend/components/ui/ComponentPanel.tsx
+++ b/frontend/components/ui/ComponentPanel.tsx
@@ -20,6 +20,7 @@ import type { EditableNodeData } from '@/lib/types';
 import { getSourceColors } from '@/lib/sourceColors';
 import { getEdgeStreamType, getNodeRuntime } from '@/lib/workflow-validation';
 import SecureTokenDisplay from './SecureTokenDisplay';
+import DockerHubBrowser from './DockerHubBrowser';
 
 function generateToken() {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
@@ -70,6 +71,7 @@ export default function ComponentPanel({
   const [basePropsOpen, setBasePropsOpen] = useState(true);
   const [customPropsOpen, setCustomPropsOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [dockerHubOpen, setDockerHubOpen] = useState(false);
 
   const autoApplyChanges = useCallback((newData: Partial<EditableNodeData>) => {
     if (selectedNode) {
@@ -341,11 +343,32 @@ export default function ComponentPanel({
                     Runtime image
                     {!getNodeRuntime({ ...selectedNode, data: formData as EditableNodeData }) && <span className="h-2 w-2 rounded-full bg-red-500" />}
                   </label>
-                  <Input
-                    name="runtime"
-                    value={typeof formData.runtime === 'string' ? formData.runtime : typeof formData.containerImage === 'string' ? formData.containerImage : ''}
-                    onChange={handleInputChange}
-                    placeholder="e.g. ghcr.io/org/plugin:latest"
+                  <div className="flex gap-2">
+                    <Input
+                      name="runtime"
+                      value={typeof formData.runtime === 'string' ? formData.runtime : typeof formData.containerImage === 'string' ? formData.containerImage : ''}
+                      onChange={handleInputChange}
+                      placeholder="e.g. ghcr.io/org/plugin:latest"
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setDockerHubOpen(true)}
+                      title="Browse Docker Hub"
+                    >
+                      Browse
+                    </Button>
+                  </div>
+                  <DockerHubBrowser
+                    open={dockerHubOpen}
+                    onClose={() => setDockerHubOpen(false)}
+                    onSelect={(imageRef) => {
+                      const newData = { runtime: imageRef };
+                      setFormData((current) => ({ ...current, ...newData }));
+                      autoApplyChanges(newData);
+                    }}
                   />
                 </div>
               )}

--- a/frontend/components/ui/DockerHubBrowser.tsx
+++ b/frontend/components/ui/DockerHubBrowser.tsx
@@ -89,6 +89,8 @@ function ApprovalBadge({ approved }: { approved: boolean }) {
 
 export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubBrowserProps) {
   const [query, setQuery] = useState('');
+  // debouncedQuery is what triggers network requests; query drives the input display only
+  const [debouncedQuery, setDebouncedQuery] = useState('');
   const [images, setImages] = useState<DockerHubImage[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState(1);
@@ -104,35 +106,46 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset state when the sheet closes
+  // Reset all state when the sheet closes
   useEffect(() => {
     if (!open) {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
       setQuery('');
+      setDebouncedQuery('');
       setImages([]);
       setTotalCount(0);
       setPage(1);
+      setLoadingImages(false);
       setSelectedImage(null);
       setTags([]);
+      setLoadingTags(false);
       setImageError(null);
       setTagError(null);
+      setTagPage(1);
+      setTagTotalCount(0);
     }
   }, [open]);
 
-  // Debounced search
+  // Update query immediately for input display; delay the actual search trigger
   const handleQueryChange = useCallback((value: string) => {
     setQuery(value);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(value);
       setPage(1);
       setSelectedImage(null);
     }, 400);
   }, []);
 
-  // Fetch images whenever query or page changes
+  // Fetch images whenever debouncedQuery or page changes
   useEffect(() => {
-    if (!query.trim()) {
+    if (!debouncedQuery.trim()) {
       setImages([]);
       setTotalCount(0);
+      setLoadingImages(false);
       return;
     }
 
@@ -140,7 +153,7 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
     setLoadingImages(true);
     setImageError(null);
 
-    fetch(`/api/dockerhub/search?query=${encodeURIComponent(query)}&page=${page}`)
+    fetch(`/api/dockerhub/search?query=${encodeURIComponent(debouncedQuery)}&page=${page}`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -161,7 +174,7 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
     return () => {
       cancelled = true;
     };
-  }, [query, page]);
+  }, [debouncedQuery, page]);
 
   // Fetch tags when an image is selected
   useEffect(() => {
@@ -222,8 +235,11 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
   const handleSelectTag = useCallback(
     (tag: DockerHubTag) => {
       if (!selectedImage) return;
-      const imageRef = `${selectedImage.repo_name}:${tag.name}`;
-      onSelect(imageRef);
+      // Strip "library/" prefix — official image refs in Docker are plain "nginx:tag", not "library/nginx:tag"
+      const repoName = selectedImage.repo_name.startsWith('library/')
+        ? selectedImage.repo_name.slice('library/'.length)
+        : selectedImage.repo_name;
+      onSelect(`${repoName}:${tag.name}`);
       onClose();
     },
     [selectedImage, onSelect, onClose],
@@ -345,7 +361,7 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
           ) : (
             /* Image search results */
             <div className="space-y-2">
-              {loadingImages && (
+              {(loadingImages || (query.trim() && query !== debouncedQuery)) && (
                 <div className="flex items-center justify-center py-8 text-slate-500">
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Searching…
@@ -358,8 +374,8 @@ export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubB
                 </div>
               )}
 
-              {!loadingImages && !imageError && query && images.length === 0 && (
-                <div className="py-6 text-center text-sm text-slate-500">No images found for "{query}".</div>
+              {!loadingImages && !imageError && debouncedQuery && images.length === 0 && (
+                <div className="py-6 text-center text-sm text-slate-500">No images found for "{debouncedQuery}".</div>
               )}
 
               {!query && (

--- a/frontend/components/ui/DockerHubBrowser.tsx
+++ b/frontend/components/ui/DockerHubBrowser.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+/**
+ * DockerHubBrowser
+ *
+ * A modal/sheet that lets users search Docker Hub, browse image tags, and
+ * select an image+tag to populate a plugin node's runtime field.
+ *
+ * Integration points
+ * ------------------
+ * - Opens from ComponentPanel when the user clicks "Browse Docker Hub" next
+ *   to the runtime input on a plugin node.
+ * - On selection, calls `onSelect(imageRef)` with a fully-qualified reference
+ *   such as `nginx:1.25` or `myorg/myimage:latest`.
+ * - Reads approval status from the backend-annotated `approved` field returned
+ *   by `GET /dockerhub/search`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AlertTriangle, CheckCircle2, ChevronLeft, Loader2, Search, Star, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DockerHubImage {
+  repo_name: string;
+  short_description: string;
+  star_count: number;
+  is_official: boolean;
+  is_automated: boolean;
+  approved: boolean;
+}
+
+interface DockerHubTag {
+  name: string;
+  full_size: number;
+  last_updated: string;
+}
+
+interface DockerHubBrowserProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the selected image reference, e.g. "nginx:latest". */
+  onSelect: (imageRef: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function ApprovalBadge({ approved }: { approved: boolean }) {
+  if (approved) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        <CheckCircle2 className="h-3 w-3" />
+        Approved
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-yellow-200 bg-yellow-50 px-2 py-0.5 text-xs font-medium text-yellow-700">
+      <AlertTriangle className="h-3 w-3" />
+      Not approved
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function DockerHubBrowser({ open, onClose, onSelect }: DockerHubBrowserProps) {
+  const [query, setQuery] = useState('');
+  const [images, setImages] = useState<DockerHubImage[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loadingImages, setLoadingImages] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+
+  const [selectedImage, setSelectedImage] = useState<DockerHubImage | null>(null);
+  const [tags, setTags] = useState<DockerHubTag[]>([]);
+  const [loadingTags, setLoadingTags] = useState(false);
+  const [tagError, setTagError] = useState<string | null>(null);
+  const [tagPage, setTagPage] = useState(1);
+  const [tagTotalCount, setTagTotalCount] = useState(0);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset state when the sheet closes
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setImages([]);
+      setTotalCount(0);
+      setPage(1);
+      setSelectedImage(null);
+      setTags([]);
+      setImageError(null);
+      setTagError(null);
+    }
+  }, [open]);
+
+  // Debounced search
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPage(1);
+      setSelectedImage(null);
+    }, 400);
+  }, []);
+
+  // Fetch images whenever query or page changes
+  useEffect(() => {
+    if (!query.trim()) {
+      setImages([]);
+      setTotalCount(0);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingImages(true);
+    setImageError(null);
+
+    fetch(`/api/dockerhub/search?query=${encodeURIComponent(query)}&page=${page}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setImages(data.results ?? []);
+        setTotalCount(data.count ?? 0);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setImageError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingImages(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [query, page]);
+
+  // Fetch tags when an image is selected
+  useEffect(() => {
+    if (!selectedImage) return;
+
+    let cancelled = false;
+    setLoadingTags(true);
+    setTagError(null);
+    setTags([]);
+    setTagPage(1);
+    setTagTotalCount(0);
+
+    const [namespace, repo] = selectedImage.repo_name.includes('/')
+      ? selectedImage.repo_name.split('/', 2)
+      : ['library', selectedImage.repo_name];
+
+    fetch(`/api/dockerhub/tags/${encodeURIComponent(namespace)}/${encodeURIComponent(repo)}?page=1`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setTags(data.results ?? []);
+        setTagTotalCount(data.count ?? 0);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setTagError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTags(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedImage]);
+
+  // Load more tags
+  const loadMoreTags = useCallback(() => {
+    if (!selectedImage) return;
+    const nextPage = tagPage + 1;
+    setTagPage(nextPage);
+
+    const [namespace, repo] = selectedImage.repo_name.includes('/')
+      ? selectedImage.repo_name.split('/', 2)
+      : ['library', selectedImage.repo_name];
+
+    fetch(`/api/dockerhub/tags/${encodeURIComponent(namespace)}/${encodeURIComponent(repo)}?page=${nextPage}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setTags((prev) => [...prev, ...(data.results ?? [])]);
+      })
+      .catch(() => {/* silently ignore pagination errors */});
+  }, [selectedImage, tagPage]);
+
+  const handleSelectTag = useCallback(
+    (tag: DockerHubTag) => {
+      if (!selectedImage) return;
+      const imageRef = `${selectedImage.repo_name}:${tag.name}`;
+      onSelect(imageRef);
+      onClose();
+    },
+    [selectedImage, onSelect, onClose],
+  );
+
+  const pageSize = 20;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  return (
+    <Sheet open={open} onOpenChange={onClose} modal>
+      <SheetContent side="right" className="flex w-[480px] flex-col overflow-hidden border-none sm:w-[560px]">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Search className="h-4 w-4" />
+            Browse Docker Hub
+          </SheetTitle>
+          <SheetDescription>
+            Search for container images, browse tags, and select one to populate the plugin runtime field.
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Search input */}
+        <div className="mt-4 flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              className="pl-9"
+              placeholder="Search images (e.g. nginx, python, redis…)"
+              value={query}
+              onChange={(e) => handleQueryChange(e.target.value)}
+              autoFocus
+            />
+          </div>
+          {query && (
+            <Button variant="ghost" size="icon" onClick={() => handleQueryChange('')}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+
+        {/* Main content area */}
+        <div className="mt-4 flex-1 overflow-y-auto">
+          {/* Tag browser (image selected) */}
+          {selectedImage ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setSelectedImage(null)}>
+                  <ChevronLeft className="mr-1 h-4 w-4" />
+                  Back to results
+                </Button>
+              </div>
+
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <div className="font-semibold text-slate-900">{selectedImage.repo_name}</div>
+                    <div className="mt-1 text-sm text-slate-600">{selectedImage.short_description || 'No description available.'}</div>
+                  </div>
+                  <ApprovalBadge approved={selectedImage.approved} />
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+                  <span className="flex items-center gap-1">
+                    <Star className="h-3 w-3" />
+                    {selectedImage.star_count.toLocaleString()} stars
+                  </span>
+                  {selectedImage.is_official && (
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700">Official</span>
+                  )}
+                </div>
+                {!selectedImage.approved && (
+                  <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800">
+                    <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
+                    This image is not on the approved allowlist. You can still select it, but deployment will be blocked until an admin approves it.
+                  </div>
+                )}
+              </div>
+
+              <div className="text-sm font-medium text-slate-700">
+                Tags{tagTotalCount > 0 ? ` (${tagTotalCount} total)` : ''}
+              </div>
+
+              {loadingTags && (
+                <div className="flex items-center justify-center py-8 text-slate-500">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Loading tags…
+                </div>
+              )}
+
+              {tagError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  Failed to load tags: {tagError}
+                </div>
+              )}
+
+              {!loadingTags && tags.length === 0 && !tagError && (
+                <div className="py-6 text-center text-sm text-slate-500">No tags found.</div>
+              )}
+
+              <div className="space-y-2">
+                {tags.map((tag) => (
+                  <button
+                    key={tag.name}
+                    type="button"
+                    onClick={() => handleSelectTag(tag)}
+                    className="flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:border-blue-300 hover:bg-blue-50"
+                  >
+                    <span className="font-mono text-sm font-medium text-slate-900">{tag.name}</span>
+                    <span className="text-xs text-slate-500">{tag.full_size ? formatBytes(tag.full_size) : ''}</span>
+                  </button>
+                ))}
+              </div>
+
+              {tags.length < tagTotalCount && (
+                <Button variant="outline" size="sm" className="w-full" onClick={loadMoreTags}>
+                  Load more tags
+                </Button>
+              )}
+            </div>
+          ) : (
+            /* Image search results */
+            <div className="space-y-2">
+              {loadingImages && (
+                <div className="flex items-center justify-center py-8 text-slate-500">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Searching…
+                </div>
+              )}
+
+              {imageError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  Search failed: {imageError}
+                </div>
+              )}
+
+              {!loadingImages && !imageError && query && images.length === 0 && (
+                <div className="py-6 text-center text-sm text-slate-500">No images found for "{query}".</div>
+              )}
+
+              {!query && (
+                <div className="py-8 text-center text-sm text-slate-500">
+                  Type a keyword above to search Docker Hub.
+                </div>
+              )}
+
+              {images.map((image) => (
+                <button
+                  key={image.repo_name}
+                  type="button"
+                  onClick={() => setSelectedImage(image)}
+                  className="flex w-full flex-col gap-1 rounded-xl border border-slate-200 bg-white p-4 text-left transition-colors hover:border-blue-300 hover:bg-blue-50"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-semibold text-slate-900">{image.repo_name}</span>
+                    <ApprovalBadge approved={image.approved} />
+                  </div>
+                  <div className="line-clamp-2 text-sm text-slate-600">
+                    {image.short_description || 'No description available.'}
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+                    <span className="flex items-center gap-1">
+                      <Star className="h-3 w-3" />
+                      {image.star_count.toLocaleString()}
+                    </span>
+                    {image.is_official && (
+                      <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700">Official</span>
+                    )}
+                  </div>
+                </button>
+              ))}
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between pt-2 text-sm text-slate-600">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page === 1}
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  >
+                    Previous
+                  </Button>
+                  <span>
+                    Page {page} of {totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= totalPages}
+                    onClick={() => setPage((p) => p + 1)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary

This PR resolves issues #33, #34, #35, and #36 in a single change set.

---

### Issue #33 — Docker Hub browser for discovering and selecting container images

**Backend**
- `backend/dockerhub.py`: Async proxy for the public Docker Hub v2 API. Handles CORS, annotates every search result with its allowlist approval status via `is_approved()`, and exposes tag pagination.
- `backend/main.py`: Two new endpoints:
  - `GET /dockerhub/search?query=&page=&page_size=`
  - `GET /dockerhub/tags/{namespace}/{repo}?page=`
- `backend/tests/test_dockerhub.py`: 7 unit tests (search annotation, pagination forwarding, tag fetching, 502 propagation, API endpoint shape).

**Frontend**
- `frontend/app/api/dockerhub/search/route.ts`: Next.js proxy route for search.
- `frontend/app/api/dockerhub/tags/[namespace]/[repo]/route.ts`: Next.js proxy route for tags.
- `frontend/components/ui/DockerHubBrowser.tsx`: Modal sheet with debounced search, paginated image results, approval badges (green = approved, yellow = not approved), tag browser, and one-click runtime field population.
- `frontend/components/ui/ComponentPanel.tsx`: Added a **Browse** button next to the runtime input on plugin nodes; opens `DockerHubBrowser` and writes the selected `image:tag` back to the node's `runtime` field.

---

### Issue #34 — Dockerized test sender container

- `docker_images/test_sender/main.py`: FastAPI app that publishes JSON messages (`{node_id, seq, ts}`) to Corelink `OUT_*` streams at a configurable `SEND_INTERVAL_MS`. Falls back to HTTP-only mode when Corelink credentials are absent.
- `docker_images/test_sender/Dockerfile`, `requirements.txt`, `README.md`
- `backend/tests/test_docker_sender.py`: 4 smoke tests (health, status, stream env parsing, initial message count).

---

### Issue #35 — Dockerized test receiver container

- `docker_images/test_receiver/main.py`: FastAPI app that subscribes to Corelink `IN_*` streams and tracks `messages_received` + `last_message`. Falls back to HTTP-only mode when Corelink credentials are absent.
- `docker_images/test_receiver/Dockerfile`, `requirements.txt`, `README.md`
- `backend/tests/test_docker_receiver.py`: 4 smoke tests.

---

### Issue #36 — Dockerized test plugin container

- `docker_images/test_plugin/main.py`: FastAPI app that receives on `IN_*` streams, applies a transform (adds `processed_by` + `processed_at` fields), and publishes to `OUT_*` streams. Compatible with `executor.py` spin-up flow.
- `docker_images/test_plugin/Dockerfile`, `requirements.txt`, `README.md`
- `backend/config/allowed_images.json`: Added `test-sender:latest`, `test-receiver:latest`, `test-plugin:latest` to the allowlist.
- `backend/tests/test_docker_plugin.py`: 6 smoke tests including transform correctness and allowlist membership assertion.

---

### CI note

The updated `.github/workflows/backend-pytest.yml` (adding three Docker build jobs and new pytest steps) is included in the commit history of this branch but was reverted to the `main` version in the final commit because the GitHub App token used for this PR does not have the `workflows` permission. The workflow diff is available in the earlier commit (`b81811c`) and can be merged separately by a maintainer with the appropriate token scope.

---

## Test results

All **87 backend tests** pass locally:

```
87 passed in 0.80s
```

Closes #33
Closes #34
Closes #35
Closes #36