### PR TITLE
Add /health liveness and /health/ready readiness endpoints

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -48,6 +48,9 @@ jobs:
       - name: "[backend] Plugin upload validation"
         run: python -m pytest tests/test_plugin_validation.py -v
 
+      - name: "[backend] Health endpoints"
+        run: python -m pytest tests/test_health.py -v
+
   # ── Job 2: Reference plugin unit tests ────────────────────────────────────
   reference-plugin:
     name: Reference Plugin Tests

--- a/backend/health.py
+++ b/backend/health.py
@@ -1,0 +1,34 @@
+"""Liveness and readiness checks for the backend API."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class CheckResult:
+    ok: bool
+    error: Optional[str] = None
+
+
+def check_docker(timeout: float = 3.0) -> CheckResult:
+    """Return whether the Docker daemon is reachable via `docker info`."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return CheckResult(ok=False, error="docker binary not found")
+    except subprocess.TimeoutExpired:
+        return CheckResult(ok=False, error="docker info timed out")
+
+    if result.returncode == 0:
+        return CheckResult(ok=True)
+
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    return CheckResult(ok=False, error=stderr or f"docker info exited {result.returncode}")

--- a/backend/health.py
+++ b/backend/health.py
@@ -26,6 +26,8 @@ def check_docker(timeout: float = 3.0) -> CheckResult:
         return CheckResult(ok=False, error="docker binary not found")
     except subprocess.TimeoutExpired:
         return CheckResult(ok=False, error="docker info timed out")
+    except OSError as exc:
+        return CheckResult(ok=False, error=str(exc) or "failed to execute docker info")
 
     if result.returncode == 0:
         return CheckResult(ok=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from corelink_health import check_corelink_health
 from deployment import deploy
 from executor import execute_dag
 from executors import ContainerSpec, get_executor
+from health import check_docker
 from inventory import load_inventory
 from plugin_validation import ValidationResult, registry_login, validate_plugin_upload
 from workflow_types import DeployWorkflow
@@ -90,6 +91,26 @@ async def upload_plugin(file: UploadFile) -> ValidationResult:
     if not result.valid:
         raise HTTPException(status_code=422, detail=result.errors)
     return result
+
+
+@app.get("/health")
+async def health():
+    """Liveness probe. Returns 200 if the process can serve requests."""
+    return {"status": "ok"}
+
+
+@app.get("/health/ready")
+async def readiness():
+    """Readiness probe. Verifies downstream dependencies are reachable."""
+    docker = check_docker()
+    checks = {"docker": {"ok": docker.ok, "error": docker.error}}
+    ready = all(c["ok"] for c in checks.values())
+    if not ready:
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "not_ready", "checks": checks},
+        )
+    return {"status": "ready", "checks": checks}
 
 
 @app.get("/health/corelink")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import asdict
 
@@ -102,7 +103,7 @@ async def health():
 @app.get("/health/ready")
 async def readiness():
     """Readiness probe. Verifies downstream dependencies are reachable."""
-    docker = check_docker()
+    docker = await asyncio.to_thread(check_docker)
     checks = {"docker": {"ok": docker.ok, "error": docker.error}}
     ready = all(c["ok"] for c in checks.values())
     if not ready:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ pydantic==2.11.7
 pydantic-core==2.33.2
 pyjwt==2.10.1
 python-dateutil==2.9.0.post0
+python-multipart==0.0.20
 realtime==2.6.0
 six==1.17.0
 sniffio==1.3.1

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,104 @@
+"""Tests for the /health liveness and /health/ready readiness endpoints."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import health
+from health import CheckResult, check_docker
+from main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+class TestLivenessEndpoint:
+    def test_returns_ok(self, client: TestClient) -> None:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    def test_does_not_depend_on_docker(self, client: TestClient) -> None:
+        with patch.object(
+            health, "check_docker", return_value=CheckResult(ok=False, error="nope")
+        ):
+            response = client.get("/health")
+        assert response.status_code == 200
+
+
+class TestReadinessEndpoint:
+    def test_ready_when_docker_ok(self, client: TestClient) -> None:
+        with patch("main.check_docker", return_value=CheckResult(ok=True)):
+            response = client.get("/health/ready")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ready"
+        assert body["checks"]["docker"] == {"ok": True, "error": None}
+
+    def test_not_ready_when_docker_down(self, client: TestClient) -> None:
+        with patch(
+            "main.check_docker",
+            return_value=CheckResult(ok=False, error="Cannot connect to Docker daemon"),
+        ):
+            response = client.get("/health/ready")
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert detail["status"] == "not_ready"
+        assert detail["checks"]["docker"]["ok"] is False
+        assert "Cannot connect" in detail["checks"]["docker"]["error"]
+
+
+class TestCheckDocker:
+    def test_returns_ok_when_docker_info_succeeds(self) -> None:
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        with patch("health.subprocess.run", return_value=fake) as mock_run:
+            result = check_docker()
+
+        assert result.ok is True
+        assert result.error is None
+        mock_run.assert_called_once()
+
+    def test_returns_error_on_nonzero_exit(self) -> None:
+        fake = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr=b"Cannot connect to the Docker daemon\n"
+        )
+        with patch("health.subprocess.run", return_value=fake):
+            result = check_docker()
+
+        assert result.ok is False
+        assert "Cannot connect to the Docker daemon" in result.error
+
+    def test_returns_error_on_empty_stderr(self) -> None:
+        fake = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+        with patch("health.subprocess.run", return_value=fake):
+            result = check_docker()
+
+        assert result.ok is False
+        assert "exited 2" in result.error
+
+    def test_returns_error_when_binary_missing(self) -> None:
+        with patch("health.subprocess.run", side_effect=FileNotFoundError()):
+            result = check_docker()
+
+        assert result.ok is False
+        assert "docker binary not found" in result.error
+
+    def test_returns_error_on_timeout(self) -> None:
+        with patch(
+            "health.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker info", timeout=3.0),
+        ):
+            result = check_docker()
+
+        assert result.ok is False
+        assert "timed out" in result.error

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,13 +10,16 @@ from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import health
+import main
 from health import CheckResult, check_docker
 from main import app
 
 
 @pytest.fixture
-def client() -> TestClient:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # Keep TestClient lifespan from triggering a real `docker login` via
+    # registry_login() if registry env vars happen to be set in the environment.
+    monkeypatch.setattr(main, "registry_login", lambda: None)
     return TestClient(app)
 
 
@@ -27,11 +30,15 @@ class TestLivenessEndpoint:
         assert response.json() == {"status": "ok"}
 
     def test_does_not_depend_on_docker(self, client: TestClient) -> None:
-        with patch.object(
-            health, "check_docker", return_value=CheckResult(ok=False, error="nope")
-        ):
+        # /health must never probe Docker; any call here would indicate a regression.
+        sentinel = patch(
+            "main.check_docker",
+            side_effect=AssertionError("/health must not call check_docker"),
+        )
+        with sentinel:
             response = client.get("/health")
         assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
 
 
 class TestReadinessEndpoint:
@@ -102,3 +109,13 @@ class TestCheckDocker:
 
         assert result.ok is False
         assert "timed out" in result.error
+
+    def test_returns_error_on_permission_error(self) -> None:
+        with patch(
+            "health.subprocess.run",
+            side_effect=PermissionError(13, "Permission denied"),
+        ):
+            result = check_docker()
+
+        assert result.ok is False
+        assert "Permission denied" in result.error


### PR DESCRIPTION
Closes #54.

## Summary
- `GET /health` — basic liveness probe, always returns `{"status": "ok"}` if the process can serve requests. Safe for load balancers and Docker healthchecks since it doesn't touch downstream dependencies.
- `GET /health/ready` — readiness probe that verifies the Docker daemon is reachable via `docker info`. Returns 200 with a per-check report on success, 503 on failure. This matches the shape of `/health/corelink` so the two can be composed later if we want to add more subsystems.
- Extracted the Docker check into `backend/health.py` so it can be unit-tested independently of the FastAPI app.
- Pinned `python-multipart==0.0.20` in `requirements.txt`. It was already required at import time by the existing `/upload/plugin` endpoint (FastAPI raises `RuntimeError` on startup without it), so this also fixes a latent missing dependency.

## Why split liveness from readiness
Liveness must stay trivial — if it called Docker, a transient daemon hiccup would make Kubernetes/ECS restart an otherwise healthy process. Readiness is the right place to fail when we can't do useful work, so load balancers stop routing traffic until Docker recovers.

## Test plan
- [x] `pytest tests/test_health.py` — 9 new tests covering liveness, readiness (both states), and the `check_docker` helper (success, non-zero exit, empty stderr, missing binary, timeout).
- [x] Full backend suite still passes (74 total).
- [x] CI workflow updated to run `tests/test_health.py`.

https://claude.ai/code/session_01X6pv1wsokgHeCy5MuU12fg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6pv1wsokgHeCy5MuU12fg)_