### PR TITLE
Add toast notifications and graceful errors for deploy flow

### DIFF
--- a/frontend/components/canvas/MinimalCanvas.tsx
+++ b/frontend/components/canvas/MinimalCanvas.tsx
@@ -20,6 +20,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { Copy, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 import CanvasPanel from '../ui/CanvasPanel';
 import AnalyzerPanel from '../ui/AnalyzerPanel';
 import {
@@ -44,6 +45,7 @@ import type {
 import { AnimatedSVGEdge } from './AnimatedSVGEdge';
 import { analyzeDAG, type AnalysisResult, type AnalyzerIssue } from '../../lib/dag-analyzer';
 import { getEdgeStreamType, getNodeOutputTypes } from '../../lib/workflow-validation';
+import { postDeploy, summarizeDeploySuccess } from '../../lib/deploy-client';
 
 function getDefaultNodeData(type: NodeType, template?: NodeTemplate): EditableNodeData {
   const baseToken = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `token-${Date.now()}`;
@@ -391,61 +393,45 @@ function FlowContent() {
     setIsValidatingBackend(true);
     setValidationMessage('Validating workflow with backend rules…');
 
-    try {
-      const response = await fetch('/api/deploy', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nodes, edges, dryRun: true }),
-      });
-
-      const result = await response.json();
-      if (result.analysis) {
-        setAnalysisResult(result.analysis);
-      }
-
-      if (!response.ok) {
-        setValidationMessage(result.backendError || result.message || 'Backend validation failed.');
-        return;
-      }
-
-      const queuedPlugins = result.backendPlan?.queued_plugins?.length ?? 0;
-      setValidationMessage(`${result.message} Queued plugin deployments: ${queuedPlugins}.`);
-    } catch (error) {
-      setValidationMessage(error instanceof Error ? error.message : 'Backend validation failed.');
-    } finally {
-      setIsValidatingBackend(false);
+    const result = await postDeploy({ nodes, edges, dryRun: true });
+    if (result.analysis) {
+      setAnalysisResult(result.analysis);
     }
+
+    if (result.ok) {
+      const summary = summarizeDeploySuccess(result, 'validate');
+      setValidationMessage(summary);
+      toast.success('Backend validation passed', { description: summary });
+    } else {
+      setValidationMessage(result.message);
+      const title = result.kind === 'network' ? 'Backend unreachable' : 'Validation failed';
+      toast.error(title, { description: result.message });
+    }
+
+    setIsValidatingBackend(false);
   }, [edges, nodes]);
 
   const handleDeploy = useCallback(async () => {
     setIsDeploying(true);
     setValidationMessage('Running deploy dry run…');
 
-    try {
-      const response = await fetch('/api/deploy', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nodes, edges }),
-      });
-
-      const result = await response.json();
-      if (result.analysis) {
-        setAnalysisResult(result.analysis);
-      }
-
-      if (!response.ok) {
-        setValidationMessage(result.backendError || result.message || 'Deployment dry run failed.');
-        return;
-      }
-
-      const orderedNodes = result.backendPlan?.topological_order?.length ?? 0;
-      setValidationMessage(`${result.message} Planned topological steps: ${orderedNodes}.`);
-      setShowDeployConfirm(false);
-    } catch (error) {
-      setValidationMessage(error instanceof Error ? error.message : 'Deployment dry run failed.');
-    } finally {
-      setIsDeploying(false);
+    const result = await postDeploy({ nodes, edges });
+    if (result.analysis) {
+      setAnalysisResult(result.analysis);
     }
+
+    if (result.ok) {
+      const summary = summarizeDeploySuccess(result, 'deploy');
+      setValidationMessage(summary);
+      toast.success('Deployment dry run succeeded', { description: summary });
+      setShowDeployConfirm(false);
+    } else {
+      setValidationMessage(result.message);
+      const title = result.kind === 'network' ? 'Backend unreachable' : 'Deployment failed';
+      toast.error(title, { description: result.message });
+    }
+
+    setIsDeploying(false);
   }, [edges, nodes]);
 
   useEffect(() => {

--- a/frontend/lib/deploy-client.test.ts
+++ b/frontend/lib/deploy-client.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+import type { EditableNodeData } from './types';
+import { postDeploy, summarizeDeploySuccess, type DeployResult } from './deploy-client';
+
+function makeRequest(): { nodes: Node<EditableNodeData>[]; edges: Edge[] } {
+  return { nodes: [], edges: [] };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+describe('postDeploy', () => {
+  it('returns a success result when the backend accepts the workflow', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      success: true,
+      valid: true,
+      message: 'Frontend and backend validation both passed.',
+      analysis: { valid: true, issues: [], stats: { errorCount: 0, warningCount: 0, readyToDeployCount: 1 } },
+      backendPlan: { queued_plugins: [{ id: 'p-1' }, { id: 'p-2' }], topological_order: ['n-1', 'n-2', 'n-3'] },
+    }));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/deploy');
+    expect(result.kind).toBe('success');
+    expect(result.ok).toBe(true);
+    expect(result.analysis?.valid).toBe(true);
+    expect(result.backendPlan?.queued_plugins).toHaveLength(2);
+  });
+
+  it('omits the dryRun flag from the body unless requested', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message: 'ok' }));
+
+    await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+    const firstBody = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(firstBody).not.toHaveProperty('dryRun');
+
+    await postDeploy({ ...makeRequest(), dryRun: true }, fetchMock as unknown as typeof fetch);
+    const secondBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(secondBody.dryRun).toBe(true);
+  });
+
+  it('returns a validation result with the backend error message on a 400', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      success: false,
+      valid: false,
+      message: 'Backend validation reported blocking issues.',
+      backendError: 'Plugin runtime image is not reachable from the registry.',
+    }, { status: 400 }));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('validation');
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe('Plugin runtime image is not reachable from the registry.');
+  });
+
+  it('falls back to message when backendError is missing on an error response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      success: false,
+      message: 'Failed to validate workflow.',
+      details: 'python3: command not found',
+    }, { status: 500 }));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('validation');
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe('python3: command not found');
+  });
+
+  it('returns a network result when fetch throws', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('network');
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe('Failed to fetch');
+  });
+
+  it('returns a sensible default message when fetch throws a non-Error value', async () => {
+    const fetchMock = vi.fn().mockRejectedValue('boom');
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('network');
+    expect(result.message).toMatch(/backend/i);
+  });
+
+  it('handles non-JSON error responses without throwing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('<html>500</html>', { status: 502 }));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('validation');
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Backend validation failed/i);
+  });
+
+  it('treats success: false in a 200 body as a non-ok unknown result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      success: false,
+      message: 'Soft failure',
+    }));
+
+    const result = await postDeploy(makeRequest(), fetchMock as unknown as typeof fetch);
+
+    expect(result.kind).toBe('unknown');
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe('Soft failure');
+  });
+});
+
+describe('summarizeDeploySuccess', () => {
+  const baseResult: DeployResult = {
+    kind: 'success',
+    ok: true,
+    message: 'Validation passed.',
+    backendPlan: { queued_plugins: [{}, {}], topological_order: ['a', 'b', 'c'] },
+  };
+
+  it('formats the validate-mode summary using queued_plugins length', () => {
+    expect(summarizeDeploySuccess(baseResult, 'validate')).toBe('Validation passed. Queued plugin deployments: 2.');
+  });
+
+  it('formats the deploy-mode summary using topological_order length', () => {
+    expect(summarizeDeploySuccess(baseResult, 'deploy')).toBe('Validation passed. Planned topological steps: 3.');
+  });
+
+  it('falls back to zero when backendPlan fields are missing', () => {
+    const result: DeployResult = { kind: 'success', ok: true, message: 'ok' };
+    expect(summarizeDeploySuccess(result, 'validate')).toBe('ok Queued plugin deployments: 0.');
+    expect(summarizeDeploySuccess(result, 'deploy')).toBe('ok Planned topological steps: 0.');
+  });
+});

--- a/frontend/lib/deploy-client.ts
+++ b/frontend/lib/deploy-client.ts
@@ -1,0 +1,121 @@
+import type { Edge, Node } from '@xyflow/react';
+import type { AnalysisResult } from './dag-analyzer';
+import type { EditableNodeData } from './types';
+
+export type DeployResultKind = 'success' | 'validation' | 'network' | 'unknown';
+
+export interface DeployResult {
+  kind: DeployResultKind;
+  ok: boolean;
+  message: string;
+  analysis?: AnalysisResult;
+  backendPlan?: {
+    queued_plugins?: unknown[];
+    topological_order?: unknown[];
+    [key: string]: unknown;
+  };
+}
+
+export interface DeployRequest {
+  nodes: Node<EditableNodeData>[];
+  edges: Edge[];
+  dryRun?: boolean;
+}
+
+const DEFAULT_VALIDATION_MESSAGE = 'Backend validation failed.';
+const DEFAULT_NETWORK_MESSAGE = 'Could not reach the deployment backend. Check your connection and try again.';
+const DEFAULT_UNKNOWN_MESSAGE = 'Deployment failed for an unknown reason.';
+
+function pickErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') {
+    return fallback;
+  }
+  const record = payload as Record<string, unknown>;
+  const candidates = [record.backendError, record.details, record.message];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return fallback;
+}
+
+export async function postDeploy(
+  request: DeployRequest,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DeployResult> {
+  let response: Response;
+  try {
+    response = await fetchImpl('/api/deploy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nodes: request.nodes,
+        edges: request.edges,
+        ...(request.dryRun ? { dryRun: true } : {}),
+      }),
+    });
+  } catch (error) {
+    return {
+      kind: 'network',
+      ok: false,
+      message: error instanceof Error && error.message ? error.message : DEFAULT_NETWORK_MESSAGE,
+    };
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  const record = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+  const analysis = record.analysis as AnalysisResult | undefined;
+  const backendPlan = record.backendPlan as DeployResult['backendPlan'];
+
+  if (!response.ok) {
+    return {
+      kind: 'validation',
+      ok: false,
+      message: pickErrorMessage(payload, DEFAULT_VALIDATION_MESSAGE),
+      analysis,
+      backendPlan,
+    };
+  }
+
+  if (record.success === false) {
+    return {
+      kind: 'unknown',
+      ok: false,
+      message: pickErrorMessage(payload, DEFAULT_UNKNOWN_MESSAGE),
+      analysis,
+      backendPlan,
+    };
+  }
+
+  const baseMessage = typeof record.message === 'string' && record.message.length > 0
+    ? record.message
+    : 'Deployment validation passed.';
+
+  return {
+    kind: 'success',
+    ok: true,
+    message: baseMessage,
+    analysis,
+    backendPlan,
+  };
+}
+
+export function summarizeDeploySuccess(result: DeployResult, mode: 'deploy' | 'validate'): string {
+  if (mode === 'validate') {
+    const queued = Array.isArray(result.backendPlan?.queued_plugins)
+      ? result.backendPlan?.queued_plugins?.length ?? 0
+      : 0;
+    return `${result.message} Queued plugin deployments: ${queued}.`;
+  }
+  const ordered = Array.isArray(result.backendPlan?.topological_order)
+    ? result.backendPlan?.topological_order?.length ?? 0
+    : 0;
+  return `${result.message} Planned topological steps: ${ordered}.`;
+}


### PR DESCRIPTION
Closes #60.

## Summary
- Extracts the `/api/deploy` POST into a typed `lib/deploy-client.ts` helper that returns a normalized `DeployResult` distinguishing `success`, `validation`, `network`, and `unknown` failures.
- Surfaces meaningful backend error messages by preferring `backendError → details → message` from the response body, with sensible defaults when the body is missing or non-JSON.
- `MinimalCanvas` now fires sonner toasts on both success and failure of the deploy and "validate with backend" actions, while keeping the inline analyzer panel message in sync. The deploy button already had an `isDeploying` loading state via `CanvasPanel`; this PR keeps that wiring intact.
- Network failures (backend unreachable, fetch throws) get a distinct "Backend unreachable" toast instead of silently swallowing the error to the console.

## Test plan
- [x] `npm test` — 16 tests pass, including 11 new tests covering the deploy client (success, dryRun flag, 400 with `backendError`, 500 fallback to `details`, fetch throws Error, fetch throws non-Error, non-JSON error body, `success: false` 200, and the success-summary formatter).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx next lint` — no warnings or errors.
- [ ] Manual: trigger a deploy with the backend stopped to verify the "Backend unreachable" toast.
- [ ] Manual: trigger a deploy with an intentionally invalid runtime image to verify the backend error message appears in the toast description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xz2eSPCqyXCDwvw814fajp)_