### PR TITLE
Add auto-connect sender/receiver demo with relay pipeline

### DIFF
--- a/backend/executors/__init__.py
+++ b/backend/executors/__init__.py
@@ -22,7 +22,11 @@ def get_executor(strategy: str | None = None) -> Executor:
     """
     strategy = strategy or os.getenv("EXECUTOR_BACKEND", "local")
 
-    if strategy == "local":
+    if strategy == "noop":
+        from .noop import NoopExecutor
+
+        return NoopExecutor()
+    elif strategy == "local":
         return LocalDockerExecutor()
     elif strategy == "ecs":
         from .ecs import ECSExecutor
@@ -36,5 +40,5 @@ def get_executor(strategy: str | None = None) -> Executor:
     else:
         raise ValueError(
             f"Unknown executor strategy: '{strategy}'. "
-            f"Supported: 'local', 'ecs'"
+            f"Supported: 'noop', 'local', 'ecs'"
         )

--- a/backend/executors/noop.py
+++ b/backend/executors/noop.py
@@ -1,0 +1,31 @@
+"""No-op executor — records the plan without starting any containers."""
+
+from .base import ContainerSpec, ContainerStatus, Executor
+
+
+class NoopExecutor(Executor):
+    """Executor that accepts every operation but does nothing.
+
+    Useful for demos, dry-run deploys, or environments without Docker.
+    """
+
+    async def start(self, spec: ContainerSpec) -> ContainerStatus:
+        return ContainerStatus(
+            node_id=spec.node_id,
+            container_id=f"noop-{spec.node_id[:12]}",
+            status="simulated",
+        )
+
+    async def stop(self, container_id: str) -> bool:
+        return True
+
+    async def status(self, container_id: str) -> ContainerStatus:
+        return ContainerStatus(
+            node_id="", container_id=container_id, status="simulated",
+        )
+
+    async def logs(self, container_id: str, tail: int = 100) -> str:
+        return ""
+
+    async def health_check(self) -> bool:
+        return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import uuid
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from dataclasses import asdict
+from typing import Dict, List
 
-from fastapi import FastAPI, HTTPException, UploadFile
+from fastapi import FastAPI, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from allowlist import check_workflow_images
+from transforms import apply_pipeline
 from allocator import allocate_nodes
 from corelink_health import check_corelink_health
 from deployment import deploy
@@ -25,6 +32,16 @@ async def _lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=_lifespan)
+
+# In-memory store of deployment plans keyed by short deployment ID
+deployments: Dict[str, dict] = {}
+
+# Message relay: per-deployment list of subscriber queues
+_relay_subscribers: Dict[str, List[asyncio.Queue]] = defaultdict(list)
+
+
+class RelayMessage(BaseModel):
+    data: str
 
 
 @app.post("/deploy")
@@ -154,8 +171,10 @@ async def deploy_and_execute_v2(
     payload: DeployWorkflow, executor: str = "local", inject_env: bool = True
 ):
     """Plan deployment and execute containers via the pluggable executor abstraction."""
+    # Never inject env vars into Docker images when using noop executor
+    effective_inject = inject_env and executor != "noop"
     try:
-        plan = deploy(payload, inject_env=inject_env)
+        plan = deploy(payload, inject_env=effective_inject)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -190,4 +209,125 @@ async def deploy_and_execute_v2(
         status = await ex.start(spec)
         results.append(asdict(status))
 
-    return {"message": "Deploy executed", "plan": plan, "execution": results}
+    deploy_id = uuid.uuid4().hex[:8]
+    deployments[deploy_id] = {
+        "plan": plan,
+        "execution": results,
+        "workflow": payload.model_dump(),
+    }
+
+    return {
+        "message": "Deploy executed",
+        "deploy_id": deploy_id,
+        "plan": plan,
+        "execution": results,
+    }
+
+
+@app.get("/deployments")
+async def list_deployments():
+    """List active deployments."""
+    return {
+        deploy_id: {
+            "node_count": dep["plan"]["node_count"],
+            "edge_count": dep["plan"]["edge_count"],
+            "queued_plugins": dep["plan"]["queued_plugins"],
+        }
+        for deploy_id, dep in deployments.items()
+    }
+
+
+@app.get("/deployments/{deploy_id}/credentials")
+async def get_deployment_credentials(
+    deploy_id: str,
+    role: str = Query(..., pattern="^(sender|receiver)$"),
+):
+    """Return Corelink connection credentials for a sender or receiver in a deployment."""
+    if deploy_id not in deployments:
+        raise HTTPException(status_code=404, detail=f"Deployment '{deploy_id}' not found")
+
+    dep = deployments[deploy_id]
+    plan = dep["plan"]
+    workflow = dep["workflow"]
+    creds_by_node = plan["credentials_by_node"]
+    nodes = workflow["nodes"]
+
+    # Find the first node matching the requested role
+    target_node = None
+    for node in nodes:
+        node_type = node.get("type", "")
+        if role == "sender" and node_type == "sender":
+            target_node = node
+            break
+        if role == "receiver" and node_type == "receiver":
+            target_node = node
+            break
+
+    if not target_node:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No {role} node found in deployment '{deploy_id}'",
+        )
+
+    node_id = target_node["id"]
+    node_creds = creds_by_node.get(node_id, {})
+
+    # Sender needs out_creds to publish; receiver needs in_creds to subscribe
+    if role == "sender":
+        stream_creds = node_creds.get("out_creds", {})
+    else:
+        stream_creds = node_creds.get("in_creds", {})
+
+    return {
+        "deploy_id": deploy_id,
+        "role": role,
+        "node_id": node_id,
+        "credentials": stream_creds,
+    }
+
+
+@app.post("/deployments/{deploy_id}/messages")
+async def post_relay_message(deploy_id: str, msg: RelayMessage):
+    """Sender pushes a message into the relay, applying plugin transforms."""
+    if deploy_id not in deployments:
+        raise HTTPException(status_code=404, detail=f"Deployment '{deploy_id}' not found")
+
+    dep = deployments[deploy_id]
+    topo_order = dep["plan"]["topological_order"]
+    nodes_by_id = {n["id"]: n for n in dep["workflow"]["nodes"]}
+
+    # Get plugin names in topological order (skip sender/receiver)
+    plugin_names = [
+        nodes_by_id[nid].get("data", {}).get("name", "")
+        for nid in topo_order
+        if nodes_by_id.get(nid, {}).get("type") == "plugin"
+    ]
+
+    transformed = apply_pipeline(plugin_names, msg.data)
+
+    for queue in _relay_subscribers[deploy_id]:
+        await queue.put(transformed)
+
+    return {"status": "ok", "listeners": len(_relay_subscribers[deploy_id])}
+
+
+@app.get("/deployments/{deploy_id}/messages")
+async def stream_relay_messages(deploy_id: str):
+    """Receiver subscribes to an SSE stream of relayed messages."""
+    if deploy_id not in deployments:
+        raise HTTPException(status_code=404, detail=f"Deployment '{deploy_id}' not found")
+
+    queue: asyncio.Queue = asyncio.Queue()
+    _relay_subscribers[deploy_id].append(queue)
+
+    async def event_generator():
+        try:
+            while True:
+                data = await queue.get()
+                yield f"data: {json.dumps({'message': data})}\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            _relay_subscribers[deploy_id].remove(queue)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/backend/transforms.py
+++ b/backend/transforms.py
@@ -1,0 +1,34 @@
+"""Lightweight plugin transforms for relay mode.
+
+Each transform is a pure function: str -> str, matching a plugin by name.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+
+def caesar_cipher(text: str, shift: int = 3) -> str:
+    result = []
+    for ch in text:
+        if ch.isalpha():
+            base = ord("A") if ch.isupper() else ord("a")
+            result.append(chr((ord(ch) - base + shift) % 26 + base))
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+# Registry: lowercased plugin name → transform function
+_TRANSFORMS: Dict[str, Callable[[str], str]] = {
+    "caesar cipher": caesar_cipher,
+}
+
+
+def apply_pipeline(plugin_names: List[str], message: str) -> str:
+    """Apply transforms in topological order for each plugin in the chain."""
+    for name in plugin_names:
+        transform = _TRANSFORMS.get(name.lower())
+        if transform:
+            message = transform(message)
+    return message

--- a/frontend/app/api/deploy/route.ts
+++ b/frontend/app/api/deploy/route.ts
@@ -19,6 +19,8 @@ export async function POST(request: NextRequest) {
     const analysis = analyzeDAG(nodes, edges);
     const workflow = toBackendDeployWorkflow(nodes, edges);
 
+    console.log('[deploy] frontend analysis valid:', analysis.valid, 'issues:', analysis.issues.length);
+
     const frontendDir = process.cwd();
     const repoDir = path.resolve(frontendDir, '..');
     const tempDir = await mkdtemp(path.join(tmpdir(), 'exp-orchestrator-validate-'));
@@ -34,7 +36,10 @@ export async function POST(request: NextRequest) {
       });
 
       const backendResult = JSON.parse(stdout || '{}');
+      console.log('[deploy] CLI validation valid:', backendResult.valid);
+
       if (!backendResult.valid) {
+        console.log('[deploy] STOPPED: CLI validation failed');
         return NextResponse.json(
           {
             success: false,
@@ -47,19 +52,57 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      if (!analysis.valid) {
+        console.log('[deploy] STOPPED: frontend analysis invalid — not calling backend');
+        const errorSummary = analysis.issues.map((i: { code: string; severity: string }) => `${i.severity}:${i.code}`).join(', ');
+        return NextResponse.json({
+          success: true,
+          valid: false,
+          message: `Backend OK but frontend analyzer blocked deploy: ${errorSummary}`,
+          analysis,
+          backendPlan: backendResult.result,
+        });
+      }
+
+      // Validation passed — execute the actual deployment
+      const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+      console.log('[deploy] calling backend:', `${backendUrl}/deploy/execute/v2?executor=noop&inject_env=false`);
+
+      const executeRes = await fetch(`${backendUrl}/deploy/execute/v2?executor=noop&inject_env=false`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(workflow),
+      });
+
+      if (!executeRes.ok) {
+        const detail = await executeRes.text();
+        console.log('[deploy] backend execute failed:', executeRes.status, detail);
+        return NextResponse.json({
+          success: true,
+          valid: true,
+          message: 'Validation passed but deployment execution failed.',
+          analysis,
+          backendPlan: backendResult.result,
+          backendError: detail,
+        });
+      }
+
+      const executeResult = await executeRes.json();
+      console.log('[deploy] SUCCESS deploy_id:', executeResult.deploy_id);
+
       return NextResponse.json({
         success: true,
-        valid: analysis.valid,
-        message: analysis.valid
-          ? 'Frontend and backend validation both passed.'
-          : 'Backend validation passed, but the frontend analyzer still found deploy blockers or warnings.',
+        valid: true,
+        message: 'Deployed successfully.',
         analysis,
         backendPlan: backendResult.result,
+        deployId: executeResult.deploy_id,
       });
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
   } catch (error) {
+    console.error('[deploy] EXCEPTION:', error);
     return NextResponse.json(
       {
         success: false,

--- a/frontend/components/canvas/MinimalCanvas.tsx
+++ b/frontend/components/canvas/MinimalCanvas.tsx
@@ -438,8 +438,16 @@ function FlowContent() {
         return;
       }
 
-      const orderedNodes = result.backendPlan?.topological_order?.length ?? 0;
-      setValidationMessage(`${result.message} Planned topological steps: ${orderedNodes}.`);
+      if (result.deployId) {
+        setValidationMessage(
+          `Deployed successfully. Deployment ID: ${result.deployId}\n` +
+          `Run: python3 scripts/sender.py ${result.deployId}\n` +
+          `Run: python3 scripts/receiver.py ${result.deployId}`
+        );
+      } else {
+        const orderedNodes = result.backendPlan?.topological_order?.length ?? 0;
+        setValidationMessage(`${result.message} Planned topological steps: ${orderedNodes}.`);
+      }
       setShowDeployConfirm(false);
     } catch (error) {
       setValidationMessage(error instanceof Error ? error.message : 'Deployment dry run failed.');

--- a/frontend/components/ui/AnalyzerPanel.tsx
+++ b/frontend/components/ui/AnalyzerPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import { AlertCircle, AlertTriangle, CheckCircle2, ChevronUp, Info, Loader2, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { AnalysisResult, AnalyzerIssue } from '@/lib/dag-analyzer';
 
@@ -47,6 +48,8 @@ export default function AnalyzerPanel({
   onValidateWithBackend,
   onFocusIssue,
 }: AnalyzerPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+
   const issues = analysisResult?.issues ?? [];
   const issuesByCategory = issues.reduce<Record<string, AnalyzerIssue[]>>((acc, issue) => {
     if (!acc[issue.category]) {
@@ -59,103 +62,146 @@ export default function AnalyzerPanel({
   const pluginCount = analysisResult?.stats.pluginCount ?? 0;
   const readyCount = analysisResult?.stats.readyToDeployCount ?? 0;
   const readinessPercent = pluginCount > 0 ? Math.round((readyCount / pluginCount) * 100) : 100;
+  const errorCount = analysisResult?.stats.errorCount ?? 0;
+  const warningCount = analysisResult?.stats.warningCount ?? 0;
 
   return (
-    <div className="absolute inset-x-4 bottom-4 z-20 rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur">
-      <div className="flex flex-col gap-4 p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
-              {analysisResult?.valid ? (
-                <CheckCircle2 className="h-4 w-4 text-green-600" />
-              ) : (
-                <AlertTriangle className="h-4 w-4 text-yellow-600" />
-              )}
-              DAG Analyzer
-            </div>
-            <p className="mt-1 text-xs text-slate-600">
+    <div
+      className="group fixed inset-x-4 bottom-0 z-20"
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+    >
+      {/* Peek tab — always visible */}
+      <div
+        className={`
+          mx-auto flex max-w-3xl cursor-pointer items-center justify-between gap-4
+          rounded-t-xl border border-b-0 border-slate-200 bg-white/95 px-4 py-2
+          shadow-lg backdrop-blur transition-transform duration-300
+          ${expanded ? '' : 'translate-y-0'}
+        `}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+          {analysisResult?.valid ? (
+            <CheckCircle2 className="h-4 w-4 text-green-600" />
+          ) : (
+            <AlertTriangle className="h-4 w-4 text-yellow-600" />
+          )}
+          DAG Analyzer
+          {errorCount > 0 && (
+            <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+              {errorCount} {errorCount === 1 ? 'blocker' : 'blockers'}
+            </span>
+          )}
+          {warningCount > 0 && (
+            <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
+              {warningCount} {warningCount === 1 ? 'warning' : 'warnings'}
+            </span>
+          )}
+          {errorCount === 0 && warningCount === 0 && (
+            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+              Ready
+            </span>
+          )}
+        </div>
+        <ChevronUp
+          className={`h-4 w-4 text-slate-400 transition-transform duration-300 ${expanded ? '' : 'rotate-180'}`}
+        />
+      </div>
+
+      {/* Expanded panel */}
+      <div
+        className={`
+          overflow-hidden rounded-t-none border border-t-0 border-slate-200
+          bg-white/95 shadow-xl backdrop-blur
+          transition-all duration-300 ease-in-out
+          ${expanded ? 'max-h-[60vh] opacity-100' : 'max-h-0 border-transparent opacity-0'}
+        `}
+      >
+        <div className="flex max-h-[60vh] flex-col gap-4 overflow-y-auto p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <p className="text-xs text-slate-600">
               Real-time deploy readiness based on cycle checks, connection rules, runtime status, and stream compatibility.
             </p>
-          </div>
-
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Button variant="outline" onClick={onValidateWithBackend} disabled={isValidating}>
-              {isValidating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-              Validate with Backend
-            </Button>
-          </div>
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-4">
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <div className="text-xs uppercase tracking-wide text-slate-500">Nodes</div>
-            <div className="mt-1 text-2xl font-semibold text-slate-900">{analysisResult?.stats.nodeCount ?? 0}</div>
-          </div>
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <div className="text-xs uppercase tracking-wide text-slate-500">Edges</div>
-            <div className="mt-1 text-2xl font-semibold text-slate-900">{analysisResult?.stats.edgeCount ?? 0}</div>
-          </div>
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <div className="text-xs uppercase tracking-wide text-slate-500">Blockers / Warnings</div>
-            <div className="mt-1 text-2xl font-semibold text-slate-900">
-              {analysisResult?.stats.errorCount ?? 0} / {analysisResult?.stats.warningCount ?? 0}
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button variant="outline" onClick={onValidateWithBackend} disabled={isValidating}>
+                {isValidating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+                Validate with Backend
+              </Button>
             </div>
           </div>
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
-              <span>Deploy readiness</span>
-              <span>{readinessPercent}%</span>
-            </div>
-            <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-200">
-              <div className="h-full rounded-full bg-emerald-500" style={{ width: `${readinessPercent}%` }} />
-            </div>
-            <div className="mt-2 text-xs text-slate-600">
-              {readyCount} of {pluginCount} plugin nodes are ready to deploy.
-            </div>
-          </div>
-        </div>
 
-        {validationMessage && (
-          <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
-            {validationMessage}
+          <div className="grid gap-3 md:grid-cols-4">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Nodes</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">{analysisResult?.stats.nodeCount ?? 0}</div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Edges</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">{analysisResult?.stats.edgeCount ?? 0}</div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Blockers / Warnings</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">
+                {errorCount} / {warningCount}
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                <span>Deploy readiness</span>
+                <span>{readinessPercent}%</span>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-200">
+                <div className="h-full rounded-full bg-emerald-500" style={{ width: `${readinessPercent}%` }} />
+              </div>
+              <div className="mt-2 text-xs text-slate-600">
+                {readyCount} of {pluginCount} plugin nodes are ready to deploy.
+              </div>
+            </div>
           </div>
-        )}
 
-        {issues.length === 0 ? (
-          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
-            No analyzer issues found. This workflow is ready for backend validation.
-          </div>
-        ) : (
-          <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-            {Object.entries(issuesByCategory).map(([category, categoryIssues]) => (
-              <details key={category} open className="rounded-lg border border-slate-200 bg-white">
-                <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium text-slate-900">
-                  {categoryLabels[category as AnalyzerIssue['category']]} ({categoryIssues.length})
-                </summary>
-                <div className="space-y-2 border-t border-slate-100 p-3">
-                  {categoryIssues.map((issue, index) => (
-                    <button
-                      key={`${category}-${index}-${issue.message}`}
-                      type="button"
-                      onClick={() => onFocusIssue(issue)}
-                      className={`w-full rounded-lg border p-3 text-left transition hover:shadow-sm ${severityClasses(issue.severity)}`}
-                    >
-                      <div className="flex items-start gap-2">
-                        <div className="mt-0.5">{severityIcon(issue.severity)}</div>
-                        <div className="min-w-0 flex-1">
-                          <div className="text-sm font-medium">{issue.message}</div>
-                          {issue.fix && (
-                            <div className="mt-1 text-xs opacity-90">Suggested fix: {issue.fix}</div>
-                          )}
+          {validationMessage && (
+            <div className="whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+              {validationMessage}
+            </div>
+          )}
+
+          {issues.length === 0 ? (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+              No analyzer issues found. This workflow is ready for backend validation.
+            </div>
+          ) : (
+            <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+              {Object.entries(issuesByCategory).map(([category, categoryIssues]) => (
+                <details key={category} open className="rounded-lg border border-slate-200 bg-white">
+                  <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium text-slate-900">
+                    {categoryLabels[category as AnalyzerIssue['category']]} ({categoryIssues.length})
+                  </summary>
+                  <div className="space-y-2 border-t border-slate-100 p-3">
+                    {categoryIssues.map((issue, index) => (
+                      <button
+                        key={`${category}-${index}-${issue.message}`}
+                        type="button"
+                        onClick={() => onFocusIssue(issue)}
+                        className={`w-full rounded-lg border p-3 text-left transition hover:shadow-sm ${severityClasses(issue.severity)}`}
+                      >
+                        <div className="flex items-start gap-2">
+                          <div className="mt-0.5">{severityIcon(issue.severity)}</div>
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium">{issue.message}</div>
+                            {issue.fix && (
+                              <div className="mt-1 text-xs opacity-90">Suggested fix: {issue.fix}</div>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </details>
-            ))}
-          </div>
-        )}
+                      </button>
+                    ))}
+                  </div>
+                </details>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/lib/nodeTemplates.ts
+++ b/frontend/lib/nodeTemplates.ts
@@ -149,12 +149,13 @@ export const nodeTemplates: NodeTemplate[] = [
       name: 'Caesar Cipher',
       description: 'Shifts letters in the alphabet by a fixed number for encryption/decryption',
       nodeType: 'plugin' as const,
+      runtime: 'ghcr.io/exp-orchestrator/caesar-cipher:latest',
       sources: ['encrypted_text', 'cipher_key'],
       access_types: {
         canSend: true,
         canReceive: true,
-        allowedSendTypes: ['text', 'cipher_key'],
-        allowedReceiveTypes: ['text', 'shift_value']
+        allowedSendTypes: ['text', 'json', 'cipher_key'],
+        allowedReceiveTypes: ['text', 'json', 'shift_value']
       }
     } as Partial<PluginNodeData>
   },

--- a/scripts/receiver.py
+++ b/scripts/receiver.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Standalone receiver that auto-connects via relay (default) or Corelink."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+import requests
+
+
+def fetch_credentials(host: str, deploy_id: str) -> dict:
+    url = f"{host}/deployments/{deploy_id}/credentials"
+    resp = requests.get(url, params={"role": "receiver"}, timeout=10)
+    if resp.status_code != 200:
+        print(f"Error fetching credentials: {resp.status_code} {resp.text}", file=sys.stderr)
+        sys.exit(1)
+    return resp.json()
+
+
+def run_relay(host: str, deploy_id: str) -> None:
+    """Receive messages from the backend SSE relay (no Corelink needed)."""
+    url = f"{host}/deployments/{deploy_id}/messages"
+
+    print(f"Receiver connected via relay (deployment: {deploy_id})")
+    print("Listening for messages (Ctrl+C to quit)...\n")
+
+    try:
+        with requests.get(url, stream=True, timeout=None) as resp:
+            if resp.status_code != 200:
+                print(f"Error: {resp.status_code} {resp.text}", file=sys.stderr)
+                sys.exit(1)
+            for line in resp.iter_lines(decode_unicode=True):
+                if not line:
+                    continue
+                if line.startswith("data: "):
+                    payload = json.loads(line[6:])
+                    print(f"[received] {payload.get('message', '')}")
+    except KeyboardInterrupt:
+        print("\nDone.")
+
+
+async def run_corelink(host: str, deploy_id: str) -> None:
+    """Receive messages from a live Corelink server."""
+    import corelink  # noqa: delayed import — only needed in corelink mode
+
+    data = fetch_credentials(host, deploy_id)
+    creds = data["credentials"]
+
+    if not creds:
+        print("No receiver credentials found in this deployment.", file=sys.stderr)
+        sys.exit(1)
+
+    stream_type = next(iter(creds))
+    cred = creds[stream_type]
+    workspace = cred["workspace"]
+    protocol = cred.get("protocol", "pubsub")
+
+    print(f"Connecting to Corelink as receiver...")
+    print(f"  Workspace : {workspace}")
+    print(f"  Data type : {stream_type}\n")
+
+    await corelink.connect("Corelink", "Corelink2023")
+
+    async def callback(data: bytes, _streamID, _header) -> None:
+        try:
+            message = data.decode("utf-8")
+        except UnicodeDecodeError:
+            message = repr(data)
+        print(f"[received] {message}")
+
+    await corelink.create_receiver(
+        workspace=workspace, protocol=protocol,
+        data_type=stream_type, on_data=callback,
+    )
+
+    print("Connected! Listening for messages (Ctrl+C to quit)...\n")
+
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        print("\nDisconnecting...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Auto-connect receiver for a deployment")
+    parser.add_argument("deploy_id", help="Deployment ID from the orchestrator")
+    parser.add_argument(
+        "--host", default="http://localhost:8000",
+        help="Backend URL (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--mode", choices=["relay", "corelink"], default="relay",
+        help="Message transport (default: relay — no Corelink server needed)",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "corelink":
+        asyncio.run(run_corelink(args.host, args.deploy_id))
+    else:
+        run_relay(args.host, args.deploy_id)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/scripts/run_receiver.sh
+++ b/scripts/run_receiver.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+  .venv/bin/pip install -q -r requirements.txt
+fi
+
+exec .venv/bin/python3 receiver.py "$@"

--- a/scripts/run_sender.sh
+++ b/scripts/run_sender.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+  .venv/bin/pip install -q -r requirements.txt
+fi
+
+exec .venv/bin/python3 sender.py "$@"

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Standalone sender that auto-connects via relay (default) or Corelink."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import requests
+
+
+def fetch_credentials(host: str, deploy_id: str) -> dict:
+    url = f"{host}/deployments/{deploy_id}/credentials"
+    resp = requests.get(url, params={"role": "sender"}, timeout=10)
+    if resp.status_code != 200:
+        print(f"Error fetching credentials: {resp.status_code} {resp.text}", file=sys.stderr)
+        sys.exit(1)
+    return resp.json()
+
+
+async def run_relay(host: str, deploy_id: str) -> None:
+    """Send messages through the backend HTTP relay (no Corelink needed)."""
+    url = f"{host}/deployments/{deploy_id}/messages"
+
+    print(f"Sender connected via relay (deployment: {deploy_id})")
+    print("Type messages to send (Ctrl+C to quit):\n")
+
+    try:
+        while True:
+            line = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: input("> ")
+            )
+            if not line:
+                continue
+            resp = requests.post(url, json={"data": line}, timeout=10)
+            if resp.status_code == 200:
+                info = resp.json()
+                print(f"  sent ({info.get('listeners', 0)} listeners)")
+            else:
+                print(f"  error: {resp.status_code} {resp.text}", file=sys.stderr)
+    except (KeyboardInterrupt, EOFError):
+        print("\nDone.")
+
+
+async def run_corelink(host: str, deploy_id: str) -> None:
+    """Send messages through a live Corelink server."""
+    import corelink  # noqa: delayed import — only needed in corelink mode
+
+    data = fetch_credentials(host, deploy_id)
+    creds = data["credentials"]
+
+    if not creds:
+        print("No sender credentials found in this deployment.", file=sys.stderr)
+        sys.exit(1)
+
+    stream_type = next(iter(creds))
+    cred = creds[stream_type]
+    workspace = cred["workspace"]
+    protocol = cred.get("protocol", "pubsub")
+
+    print(f"Connecting to Corelink as sender...")
+    print(f"  Workspace : {workspace}")
+    print(f"  Data type : {stream_type}\n")
+
+    await corelink.connect("Corelink", "Corelink2023")
+    sender = await corelink.create_sender(
+        workspace=workspace, protocol=protocol, data_type=stream_type,
+    )
+
+    print("Connected! Type messages to send (Ctrl+C to quit):\n")
+
+    try:
+        while True:
+            line = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: input("> ")
+            )
+            if not line:
+                continue
+            await sender.send(line.encode("utf-8"))
+            print(f"  sent: {line}")
+    except (KeyboardInterrupt, EOFError):
+        print("\nDisconnecting...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Auto-connect sender for a deployment")
+    parser.add_argument("deploy_id", help="Deployment ID from the orchestrator")
+    parser.add_argument(
+        "--host", default="http://localhost:8000",
+        help="Backend URL (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--mode", choices=["relay", "corelink"], default="relay",
+        help="Message transport (default: relay — no Corelink server needed)",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "corelink":
+        asyncio.run(run_corelink(args.host, args.deploy_id))
+    else:
+        asyncio.run(run_relay(args.host, args.deploy_id))


### PR DESCRIPTION
## Summary
- Adds deployment tracking with short IDs and credential endpoints for sender/receiver auto-connect
- Adds message relay (HTTP POST + SSE) with inline plugin transforms (Caesar cipher) — no Docker or Corelink needed
- Adds noop executor, collapsible DAG analyzer panel, and standalone sender/receiver scripts with shell wrappers

## Demo usage
```bash
# Start backend + frontend, deploy a sender → Caesar cipher → receiver graph from the UI
# Copy the deployment ID shown after deploy, then:
./scripts/run_receiver.sh <deploy-id>
./scripts/run_sender.sh <deploy-id>
```

## Test plan
- [ ] Deploy a sender → Caesar cipher → receiver workflow from the UI
- [ ] Verify deployment ID is shown in the analyzer panel
- [ ] Run receiver and sender scripts with the deployment ID
- [ ] Confirm sender input is Caesar-cipher-shifted in receiver output
- [ ] Verify `curl http://localhost:8000/deployments` lists active deployments
- [ ] Verify analyzer panel hides at bottom and expands on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)