### PR TITLE
Corelink-modular auto-connect demo

### DIFF
--- a/backend/config/allowed_images.json
+++ b/backend/config/allowed_images.json
@@ -3,5 +3,10 @@
     "approved": true,
     "added_by": "corelink-modular-demo",
     "notes": "Demo plugin: subscribes to IN streams, transforms, publishes to OUT streams via Corelink."
+  },
+  "caesar_cipher:latest": {
+    "approved": true,
+    "added_by": "corelink-modular-demo",
+    "notes": "Caesar cipher plugin: shifts each alphabetic character by CAESAR_SHIFT (default 10). Same Corelink wiring as corelink_demo."
   }
 }

--- a/backend/config/allowed_images.json
+++ b/backend/config/allowed_images.json
@@ -1,1 +1,7 @@
-{}
+{
+  "corelink_demo:latest": {
+    "approved": true,
+    "added_by": "corelink-modular-demo",
+    "notes": "Demo plugin: subscribes to IN streams, transforms, publishes to OUT streams via Corelink."
+  }
+}

--- a/backend/corelink_admin.py
+++ b/backend/corelink_admin.py
@@ -58,10 +58,30 @@ async def provision_deployment(deploy_id: str) -> CorelinkProvisionResult:
         raise CorelinkAdminError(f"provision failed: HTTP {resp.status_code} {resp.text}")
 
     body = resp.json()
-    return CorelinkProvisionResult(
-        workspace=body["workspace"],
-        host=body["host"],
-        port=int(body["port"]),
-        username=body["username"],
-        password=body["password"],
-    )
+    try:
+        return CorelinkProvisionResult(
+            workspace=body["workspace"],
+            host=body["host"],
+            port=int(body["port"]),
+            username=body["username"],
+            password=body["password"],
+        )
+    except (KeyError, ValueError, TypeError) as e:
+        raise CorelinkAdminError(f"corelink returned malformed provision response: {e}") from e
+
+
+async def unprovision_deployment(deploy_id: str) -> None:
+    """DELETE /api/provision/<deploy_id>. Treats 200 and 404 as success."""
+    url = f"{_server_url()}/api/provision/{deploy_id}"
+    headers = {"X-Provision-Token": _provision_token()}
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=_DEFAULT_TIMEOUT) as client:
+            resp = await client.delete(url, headers=headers)
+    except httpx.HTTPError as e:
+        raise CorelinkAdminError(f"corelink unreachable: {e}") from e
+
+    if resp.status_code in (200, 404):
+        return
+    if resp.status_code in (401, 403):
+        raise CorelinkAdminError(f"corelink rejected provision token (HTTP {resp.status_code})")
+    raise CorelinkAdminError(f"unprovision failed: HTTP {resp.status_code} {resp.text}")

--- a/backend/corelink_admin.py
+++ b/backend/corelink_admin.py
@@ -6,7 +6,12 @@ step 1 of ripping Corelink out of the backend.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+
+import httpx
+
+_DEFAULT_TIMEOUT = 5.0
 
 
 class CorelinkAdminError(Exception):
@@ -20,3 +25,43 @@ class CorelinkProvisionResult:
     port: int
     username: str
     password: str
+
+
+def _server_url() -> str:
+    host = os.getenv("CORELINK_HOST")
+    port = os.getenv("CORELINK_PORT", "20012")
+    if not host:
+        raise CorelinkAdminError("CORELINK_HOST not set")
+    return f"https://{host}:{port}"
+
+
+def _provision_token() -> str:
+    token = os.getenv("CORELINK_PROVISION_TOKEN")
+    if not token:
+        raise CorelinkAdminError("CORELINK_PROVISION_TOKEN not set")
+    return token
+
+
+async def provision_deployment(deploy_id: str) -> CorelinkProvisionResult:
+    """POST /api/provision on corelink-server. Idempotent: server returns same blob on repeat."""
+    url = f"{_server_url()}/api/provision"
+    headers = {"X-Provision-Token": _provision_token(), "Content-Type": "application/json"}
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=_DEFAULT_TIMEOUT) as client:
+            resp = await client.post(url, json={"deploy_id": deploy_id}, headers=headers)
+    except httpx.HTTPError as e:
+        raise CorelinkAdminError(f"corelink unreachable: {e}") from e
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        raise CorelinkAdminError(f"corelink rejected provision token (HTTP {resp.status_code})")
+    if resp.status_code != 200:
+        raise CorelinkAdminError(f"provision failed: HTTP {resp.status_code} {resp.text}")
+
+    body = resp.json()
+    return CorelinkProvisionResult(
+        workspace=body["workspace"],
+        host=body["host"],
+        port=int(body["port"]),
+        username=body["username"],
+        password=body["password"],
+    )

--- a/backend/corelink_admin.py
+++ b/backend/corelink_admin.py
@@ -1,0 +1,22 @@
+"""HTTP client for the corelink-server provisioning routes.
+
+All Corelink-specific deploy-time logic lives here. Removing this file is
+step 1 of ripping Corelink out of the backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class CorelinkAdminError(Exception):
+    """Raised when provisioning/unprovisioning a deployment fails."""
+
+
+@dataclass
+class CorelinkProvisionResult:
+    workspace: str
+    host: str
+    port: int
+    username: str
+    password: str

--- a/backend/deployment.py
+++ b/backend/deployment.py
@@ -24,7 +24,9 @@ def _normalize_env_key(stream_type: str) -> str:
     return normalized or "JSON"
 
 
-def process_workflow(edges: List[DeployEdge], nodes_by_id: Dict[str, DeployNode]) -> int:
+def process_workflow(
+    edges: List[DeployEdge], nodes_by_id: Dict[str, DeployNode], workspace: str
+) -> int:
     for edge in edges:
         if edge.source not in nodes_by_id:
             raise ValueError(f"Unknown source node '{edge.source}'")
@@ -50,7 +52,7 @@ def process_workflow(edges: List[DeployEdge], nodes_by_id: Dict[str, DeployNode]
                 f"Stream type {stream_type} not found in destination {dst.id} in streams"
             )
 
-        cred = generate_pub_sub_cred(stream_type, src, dst)
+        cred = generate_pub_sub_cred(stream_type, src, dst, workspace)
         src.out_creds[stream_type] = cred
         dst.in_creds[stream_type] = cred
 
@@ -70,10 +72,10 @@ def assign_deployment(deployment_queue: Deque[DeployNode]) -> List[str]:
 
 
 def generate_pub_sub_cred(
-    stream_type: str, src: DeployNode, dst: DeployNode
+    stream_type: str, src: DeployNode, dst: DeployNode, workspace: str
 ) -> StreamCredential:
     return StreamCredential(
-        workspace=f"{src.id}_{dst.id}_{stream_type}_workspace",
+        workspace=workspace,
         protocol="pubsub",
         stream_id=f"{src.id}_{dst.id}_{stream_type}_stream",
         data_type=stream_type,
@@ -142,7 +144,14 @@ def _compute_topological_order(
     return order, dict(graph)
 
 
-def deploy(workflow: DeployWorkflow, inject_env: bool = False) -> Dict[str, Any]:
+def deploy(
+    workflow: DeployWorkflow,
+    deploy_id: str = "local",
+    workspace: str | None = None,
+    inject_env: bool = False,
+) -> Dict[str, Any]:
+    if workspace is None:
+        workspace = f"workflow_{deploy_id}"
     nodes_by_id = {node.id: node.model_copy(deep=True) for node in workflow.nodes}
 
     for edge in workflow.edges:
@@ -152,7 +161,7 @@ def deploy(workflow: DeployWorkflow, inject_env: bool = False) -> Dict[str, Any]
             raise ValueError(f"Edge target '{edge.target}' not found in nodes")
 
     topo_order, dag_graph = _compute_topological_order(nodes_by_id, workflow.edges)
-    process_workflow(workflow.edges, nodes_by_id)
+    process_workflow(workflow.edges, nodes_by_id, workspace)
 
     ordered_nodes = [nodes_by_id[node_id] for node_id in topo_order]
     deployment_queue: Deque[DeployNode] = deque()
@@ -187,6 +196,8 @@ def deploy(workflow: DeployWorkflow, inject_env: bool = False) -> Dict[str, Any]
         }
 
     return {
+        "deploy_id": deploy_id,
+        "workspace": workspace,
         "node_count": len(nodes_by_id),
         "edge_count": len(workflow.edges),
         "topological_order": topo_order,
@@ -208,4 +219,4 @@ if __name__ == "__main__":
         ],
         edges=[DeployEdge(source="source", target="plugin-a", data="json")],
     )
-    print(deploy(example_workflow, inject_env=False))
+    print(deploy(example_workflow, deploy_id="example", inject_env=False))

--- a/backend/deployment.py
+++ b/backend/deployment.py
@@ -148,6 +148,7 @@ def deploy(
     workflow: DeployWorkflow,
     deploy_id: str = "local",
     workspace: str | None = None,
+    corelink_creds: Dict[str, Any] | None = None,
     inject_env: bool = False,
 ) -> Dict[str, Any]:
     if workspace is None:
@@ -174,6 +175,11 @@ def deploy(
 
     for node in deployment_queue:
         env_vars = build_env_vars(node)
+        if corelink_creds and node.type == "plugin":
+            env_vars["CORELINK_HOST"] = str(corelink_creds["host"])
+            env_vars["CORELINK_PORT"] = str(corelink_creds["port"])
+            env_vars["CORELINK_USERNAME"] = str(corelink_creds["username"])
+            env_vars["CORELINK_PASSWORD"] = str(corelink_creds["password"])
         env_plan[node.id] = env_vars
         image_name = fetch_image_name(node)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -231,6 +231,10 @@ async def deploy_and_execute_v2(
         status = await ex.start(spec)
         results.append(asdict(status))
 
+    # NOTE: demo-only — the provisioning blob (incl. corelink password) is stored
+    # in process memory and re-emitted by /deployments/{id}/credentials, which has
+    # no AuthN/AuthZ. Pre-prod hardening must gate that endpoint or scrub the
+    # password before returning it.
     deployments[deploy_id] = {
         "plan": plan,
         "execution": results,

--- a/backend/main.py
+++ b/backend/main.py
@@ -313,10 +313,22 @@ async def get_deployment_credentials(
     provisioning = dep.get("provisioning", {})
     corelink_block = None
     if provisioning:
+        # Different connections to corelink-server must use different users — the
+        # server suppresses stream-update notifications between same-user
+        # connections ("skipping stream from same user"). The plugin container
+        # uses provisioning.username (Testuser); sender/receiver get distinct
+        # seeded users so all three nodes route correctly.
+        # NOTE: demo-only — relies on corelink-server's seeded test users
+        # (Testuser1/Testuser2 with the shared Testpassword). Production would
+        # provision per-deployment users.
+        role_user = {
+            "sender": "Testuser1",
+            "receiver": "Testuser2",
+        }.get(role, provisioning["username"])
         corelink_block = {
             "host": provisioning["host"],
             "port": provisioning["port"],
-            "username": provisioning["username"],
+            "username": role_user,
             "password": provisioning["password"],
         }
     return {

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from allowlist import check_workflow_images
 from transforms import apply_pipeline
 from allocator import allocate_nodes
+import corelink_admin
 from corelink_health import check_corelink_health
 from deployment import deploy
 from executor import execute_dag
@@ -171,10 +172,31 @@ async def deploy_and_execute_v2(
     payload: DeployWorkflow, executor: str = "local", inject_env: bool = True
 ):
     """Plan deployment and execute containers via the pluggable executor abstraction."""
-    # Never inject env vars into Docker images when using noop executor
+    # Mint the deploy_id up-front so it can be the workspace key
+    deploy_id = uuid.uuid4().hex[:8]
+
+    # Provision a Corelink workspace + creds for this deployment
+    try:
+        provisioning = await corelink_admin.provision_deployment(deploy_id)
+    except corelink_admin.CorelinkAdminError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    corelink_creds = {
+        "host": provisioning.host,
+        "port": provisioning.port,
+        "username": provisioning.username,
+        "password": provisioning.password,
+    }
+
     effective_inject = inject_env and executor != "noop"
     try:
-        plan = deploy(payload, inject_env=effective_inject)
+        plan = deploy(
+            payload,
+            deploy_id=deploy_id,
+            workspace=provisioning.workspace,
+            corelink_creds=corelink_creds,
+            inject_env=effective_inject,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -209,11 +231,17 @@ async def deploy_and_execute_v2(
         status = await ex.start(spec)
         results.append(asdict(status))
 
-    deploy_id = uuid.uuid4().hex[:8]
     deployments[deploy_id] = {
         "plan": plan,
         "execution": results,
         "workflow": payload.model_dump(),
+        "provisioning": {
+            "workspace": provisioning.workspace,
+            "host": provisioning.host,
+            "port": provisioning.port,
+            "username": provisioning.username,
+            "password": provisioning.password,
+        },
     }
 
     return {
@@ -278,10 +306,20 @@ async def get_deployment_credentials(
     else:
         stream_creds = node_creds.get("in_creds", {})
 
+    provisioning = dep.get("provisioning", {})
+    corelink_block = None
+    if provisioning:
+        corelink_block = {
+            "host": provisioning["host"],
+            "port": provisioning["port"],
+            "username": provisioning["username"],
+            "password": provisioning["password"],
+        }
     return {
         "deploy_id": deploy_id,
         "role": role,
         "node_id": node_id,
+        "corelink": corelink_block,
         "credentials": stream_creds,
     }
 
@@ -331,3 +369,33 @@ async def stream_relay_messages(deploy_id: str):
             _relay_subscribers[deploy_id].remove(queue)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+@app.delete("/deployments/{deploy_id}")
+async def delete_deployment(deploy_id: str):
+    """Stop containers, unprovision Corelink workspace, remove deployment record."""
+    if deploy_id not in deployments:
+        raise HTTPException(status_code=404, detail=f"Deployment '{deploy_id}' not found")
+
+    dep = deployments[deploy_id]
+    warnings: list[str] = []
+
+    # Stop running containers (best-effort)
+    ex = get_executor()
+    for status in dep.get("execution", []):
+        cid = status.get("container_id")
+        if not cid:
+            continue
+        try:
+            await ex.stop(cid)
+        except Exception as e:
+            warnings.append(f"stop {cid} failed: {e}")
+
+    # Unprovision Corelink workspace
+    try:
+        await corelink_admin.unprovision_deployment(deploy_id)
+    except corelink_admin.CorelinkAdminError as e:
+        warnings.append(f"unprovision failed: {e}")
+
+    deployments.pop(deploy_id, None)
+    return {"status": "deleted", "deploy_id": deploy_id, "warnings": warnings}

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+# Corelink integration. Provisioning credentials come back from the corelink-server's
+# /api/provision response — we don't carry CORELINK_USERNAME/PASSWORD here.
+export CORELINK_HOST="${CORELINK_HOST:-host.docker.internal}"
+export CORELINK_PORT="${CORELINK_PORT:-20012}"
+export CORELINK_PROVISION_TOKEN="${CORELINK_PROVISION_TOKEN:-test-token}"
+
+uvicorn main:app --reload --port "${PORT:-8000}"

--- a/backend/tests/test_corelink_admin.py
+++ b/backend/tests/test_corelink_admin.py
@@ -28,3 +28,61 @@ def test_admin_error_is_exception():
     from corelink_admin import CorelinkAdminError
 
     assert issubclass(CorelinkAdminError, Exception)
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_happy_path(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+        @property
+        def text(self):
+            import json
+            return json.dumps(self._payload)
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return FakeResponse(200, {
+                "workspace": "workflow_abc12345",
+                "host": "1.2.3.4",
+                "port": 20012,
+                "username": "Testuser",
+                "password": "Testpassword",
+            })
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {"AsyncClient": FakeAsyncClient}))
+
+    result = await ca.provision_deployment("abc12345")
+
+    assert result.workspace == "workflow_abc12345"
+    assert result.host == "1.2.3.4"
+    assert result.port == 20012
+    assert result.username == "Testuser"
+    assert captured["url"] == "https://localhost:20012/api/provision"
+    assert captured["json"] == {"deploy_id": "abc12345"}
+    assert captured["headers"]["X-Provision-Token"] == "secret"

--- a/backend/tests/test_corelink_admin.py
+++ b/backend/tests/test_corelink_admin.py
@@ -167,3 +167,93 @@ async def test_provision_deployment_server_error(monkeypatch):
 
     with pytest.raises(ca.CorelinkAdminError, match="HTTP 500"):
         await ca.provision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_unprovision_deployment_happy(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+        def json(self): return {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def delete(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    await ca.unprovision_deployment("abc12345")
+    assert captured["url"] == "https://localhost:20012/api/provision/abc12345"
+    assert captured["headers"]["X-Provision-Token"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_unprovision_deployment_404_is_success(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeResponse:
+        status_code = 404
+        text = "{}"
+        def json(self): return {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def delete(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    # Should NOT raise
+    await ca.unprovision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_malformed_response_raises_admin_error(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"workspace": "wf"}'
+        def json(self): return {"workspace": "wf"}  # missing host/port/username/password
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="malformed provision response"):
+        await ca.provision_deployment("abc")

--- a/backend/tests/test_corelink_admin.py
+++ b/backend/tests/test_corelink_admin.py
@@ -1,0 +1,30 @@
+"""Unit tests for corelink_admin (mocked HTTP)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_provision_result_dataclass_shape():
+    from corelink_admin import CorelinkProvisionResult
+
+    r = CorelinkProvisionResult(
+        workspace="workflow_abc",
+        host="localhost",
+        port=20012,
+        username="Testuser",
+        password="Testpassword",
+    )
+    assert r.workspace == "workflow_abc"
+    assert r.port == 20012
+
+
+def test_admin_error_is_exception():
+    from corelink_admin import CorelinkAdminError
+
+    assert issubclass(CorelinkAdminError, Exception)

--- a/backend/tests/test_corelink_admin.py
+++ b/backend/tests/test_corelink_admin.py
@@ -86,3 +86,84 @@ async def test_provision_deployment_happy_path(monkeypatch):
     assert captured["url"] == "https://localhost:20012/api/provision"
     assert captured["json"] == {"deploy_id": "abc12345"}
     assert captured["headers"]["X-Provision-Token"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_timeout(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *args, **kwargs):
+            raise __import__("httpx").ConnectTimeout("timeout")
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+        "ConnectTimeout": ca.httpx.ConnectTimeout,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="corelink unreachable"):
+        await ca.provision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_unauthorized(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "wrong")
+
+    class FakeResponse:
+        status_code = 401
+        text = '{"error":"unauthorized"}'
+        def json(self): return {"error": "unauthorized"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="rejected provision token"):
+        await ca.provision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_server_error(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeResponse:
+        status_code = 500
+        text = '{"error":"oops"}'
+        def json(self): return {"error": "oops"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="HTTP 500"):
+        await ca.provision_deployment("abc")

--- a/backend/tests/test_deployment_planner.py
+++ b/backend/tests/test_deployment_planner.py
@@ -192,3 +192,40 @@ def test_inject_vars_to_image_uses_disposable_compose_file(
     assert "- NODE_ID=plugin-a" in captured["content"]
     assert "- IN_JSON_STREAM_ID=stream-1" in captured["content"]
     assert not compose_file.exists()
+
+
+def test_corelink_env_injected_for_plugins_only(linear_workflow: DeployWorkflow) -> None:
+    corelink = {
+        "host": "1.2.3.4",
+        "port": 20012,
+        "username": "Testuser",
+        "password": "Testpassword",
+    }
+    plan = deployment.deploy(
+        linear_workflow,
+        deploy_id="abc",
+        workspace="workflow_abc",
+        corelink_creds=corelink,
+        inject_env=False,
+    )
+    plugin_a = plan["env_plan"]["plugin-a"]
+    assert plugin_a["CORELINK_HOST"] == "1.2.3.4"
+    assert plugin_a["CORELINK_PORT"] == "20012"
+    assert plugin_a["CORELINK_USERNAME"] == "Testuser"
+    assert plugin_a["CORELINK_PASSWORD"] == "Testpassword"
+
+    # Sender/receiver nodes don't get plugin-only injection
+    # In the linear_workflow fixture there's no receiver, but plugin-b is type=plugin too.
+    # Just confirm no extraneous keys leaked.
+
+
+def test_corelink_env_omitted_when_creds_not_provided(linear_workflow: DeployWorkflow) -> None:
+    plan = deployment.deploy(
+        linear_workflow,
+        deploy_id="abc",
+        workspace="workflow_abc",
+        inject_env=False,
+    )
+    plugin_a = plan["env_plan"]["plugin-a"]
+    assert "CORELINK_HOST" not in plugin_a
+    assert "CORELINK_PASSWORD" not in plugin_a

--- a/backend/tests/test_deployment_planner.py
+++ b/backend/tests/test_deployment_planner.py
@@ -35,8 +35,10 @@ def linear_workflow() -> DeployWorkflow:
 
 
 def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWorkflow) -> None:
-    first = deployment.deploy(linear_workflow, inject_env=False)
-    second = deployment.deploy(linear_workflow, inject_env=False)
+    first = deployment.deploy(linear_workflow, deploy_id="abc12345",
+                              workspace="workflow_abc12345", inject_env=False)
+    second = deployment.deploy(linear_workflow, deploy_id="abc12345",
+                               workspace="workflow_abc12345", inject_env=False)
 
     assert first == second
     assert first["node_count"] == 3
@@ -62,8 +64,13 @@ def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWor
     assert plugin_b_env["IN_BYTES_STREAM_ID"] == "plugin-a_plugin-b_bytes_stream"
 
     assert first["credentials_by_node"]["source"]["out_creds"]["json"]["workspace"] == (
-        "source_plugin-a_json_workspace"
+        "workflow_abc12345"
     )
+    # Every credential in the plan uses the same deploy-scoped workspace
+    for node_creds in first["credentials_by_node"].values():
+        for stream_creds in (node_creds["in_creds"], node_creds["out_creds"]):
+            for cred in stream_creds.values():
+                assert cred["workspace"] == "workflow_abc12345"
     assert first["credentials_by_node"]["plugin-b"]["in_creds"]["bytes"]["stream_id"] == (
         "plugin-a_plugin-b_bytes_stream"
     )
@@ -86,7 +93,7 @@ def test_deploy_rejects_unknown_edge_endpoints(edge: DeployEdge, message: str) -
     )
 
     with pytest.raises(ValueError, match=message):
-        deployment.deploy(workflow)
+        deployment.deploy(workflow, deploy_id="test", workspace="workflow_test")
 
 
 def test_deploy_rejects_cycles() -> None:
@@ -102,7 +109,7 @@ def test_deploy_rejects_cycles() -> None:
     )
 
     with pytest.raises(ValueError, match="Cycle detected"):
-        deployment.deploy(workflow)
+        deployment.deploy(workflow, deploy_id="test", workspace="workflow_test")
 
 
 def test_deploy_rejects_stream_contract_mismatch() -> None:
@@ -118,7 +125,7 @@ def test_deploy_rejects_stream_contract_mismatch() -> None:
         ValueError,
         match="Stream type json not found in destination plugin-a in streams",
     ):
-        deployment.deploy(workflow)
+        deployment.deploy(workflow, deploy_id="test", workspace="workflow_test")
 
 
 def test_deploy_infers_streams_when_edge_contract_is_present() -> None:
@@ -130,7 +137,7 @@ def test_deploy_infers_streams_when_edge_contract_is_present() -> None:
         edges=[DeployEdge(source="source", target="plugin-a", data="parquet")],
     )
 
-    result = deployment.deploy(workflow)
+    result = deployment.deploy(workflow, deploy_id="test", workspace="workflow_test")
 
     assert result["topological_order"] == ["source", "plugin-a"]
     assert result["env_plan"]["plugin-a"]["IN_PARQUET_STREAM_ID"] == "source_plugin-a_parquet_stream"
@@ -147,7 +154,7 @@ def test_deploy_injects_env_only_for_plugins_with_images(
 
     monkeypatch.setattr(deployment, "inject_vars_to_image", fake_inject)
 
-    result = deployment.deploy(linear_workflow, inject_env=True)
+    result = deployment.deploy(linear_workflow, deploy_id="test", workspace="workflow_test", inject_env=True)
 
     assert [image_name for image_name, _ in injected] == ["test/plugin-a:latest"]
     assert result["injected_nodes"] == ["plugin-a"]

--- a/backend/tests/test_main_corelink.py
+++ b/backend/tests/test_main_corelink.py
@@ -16,8 +16,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import corelink_admin
 import main as main_module
-from executors import ContainerStatus
-from executors.noop import NoopExecutor
 
 
 def _workflow_payload():

--- a/backend/tests/test_main_corelink.py
+++ b/backend/tests/test_main_corelink.py
@@ -1,0 +1,95 @@
+"""Integration-style tests for /deploy/execute/v2 + DELETE /deployments/{id}.
+
+Mocks corelink_admin and the executor so these tests don't need Docker or a
+running Corelink server.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import corelink_admin
+import main as main_module
+from executors import ContainerStatus
+from executors.noop import NoopExecutor
+
+
+def _workflow_payload():
+    return {
+        "nodes": [
+            {"id": "src", "type": "sender", "out_streams": ["json"]},
+            {"id": "plg", "type": "plugin", "runtime": "corelink_demo:latest",
+             "in_streams": ["json"], "out_streams": ["json"]},
+            {"id": "rcv", "type": "receiver", "in_streams": ["json"]},
+        ],
+        "edges": [
+            {"source": "src", "target": "plg", "data": "json"},
+            {"source": "plg", "target": "rcv", "data": "json"},
+        ],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Mock provisioning
+    async def fake_provision(deploy_id):
+        return corelink_admin.CorelinkProvisionResult(
+            workspace=f"workflow_{deploy_id}",
+            host="1.2.3.4", port=20012,
+            username="Testuser", password="Testpassword",
+        )
+    async def fake_unprovision(deploy_id): return None
+
+    monkeypatch.setattr(corelink_admin, "provision_deployment", fake_provision)
+    monkeypatch.setattr(corelink_admin, "unprovision_deployment", fake_unprovision)
+    # Force noop executor (no Docker)
+    monkeypatch.setenv("EXECUTOR_BACKEND", "noop")
+
+    # Reset deployments dict between tests
+    main_module.deployments.clear()
+    return TestClient(main_module.app)
+
+
+def test_deploy_v2_provisions_workspace_and_returns_corelink_block(client):
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "deploy_id" in body
+    deploy_id = body["deploy_id"]
+    assert body["plan"]["workspace"] == f"workflow_{deploy_id}"
+
+    # Sender credentials response includes the new corelink block
+    cred = client.get(f"/deployments/{deploy_id}/credentials", params={"role": "sender"}).json()
+    assert cred["corelink"]["host"] == "1.2.3.4"
+    assert cred["corelink"]["port"] == 20012
+    assert cred["corelink"]["username"] == "Testuser"
+    assert cred["credentials"]["json"]["workspace"] == f"workflow_{deploy_id}"
+
+
+def test_deploy_v2_returns_503_when_provision_fails(client, monkeypatch):
+    async def boom(deploy_id):
+        raise corelink_admin.CorelinkAdminError("corelink unreachable: timeout")
+    monkeypatch.setattr(corelink_admin, "provision_deployment", boom)
+
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    assert resp.status_code == 503
+    assert "corelink unreachable" in resp.json()["detail"]
+
+
+def test_delete_deployment_unprovisions_and_removes(client):
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    deploy_id = resp.json()["deploy_id"]
+    assert deploy_id in main_module.deployments
+
+    del_resp = client.delete(f"/deployments/{deploy_id}")
+    assert del_resp.status_code == 200
+    assert deploy_id not in main_module.deployments

--- a/backend/tests/test_main_corelink.py
+++ b/backend/tests/test_main_corelink.py
@@ -63,12 +63,19 @@ def test_deploy_v2_provisions_workspace_and_returns_corelink_block(client):
     deploy_id = body["deploy_id"]
     assert body["plan"]["workspace"] == f"workflow_{deploy_id}"
 
-    # Sender credentials response includes the new corelink block
+    # Sender credentials response includes the new corelink block. The
+    # username is role-mapped (Testuser1 for sender, Testuser2 for receiver,
+    # provisioning default for plugin) so each connection to corelink-server
+    # uses a different identity — same-user connections suppress the alert
+    # routing the demo depends on.
     cred = client.get(f"/deployments/{deploy_id}/credentials", params={"role": "sender"}).json()
     assert cred["corelink"]["host"] == "1.2.3.4"
     assert cred["corelink"]["port"] == 20012
-    assert cred["corelink"]["username"] == "Testuser"
+    assert cred["corelink"]["username"] == "Testuser1"
     assert cred["credentials"]["json"]["workspace"] == f"workflow_{deploy_id}"
+
+    rcv_cred = client.get(f"/deployments/{deploy_id}/credentials", params={"role": "receiver"}).json()
+    assert rcv_cred["corelink"]["username"] == "Testuser2"
 
 
 def test_deploy_v2_returns_503_when_provision_fails(client, monkeypatch):

--- a/docs/superpowers/plans/2026-04-27-corelink-modular-demo.md
+++ b/docs/superpowers/plans/2026-04-27-corelink-modular-demo.md
@@ -1,0 +1,2818 @@
+# Corelink-modular auto-connect demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement an end-to-end Corelink demo (sender → plugin → receiver) where every Corelink-touching file lives behind a clean modular boundary so post-demo rip-out is a small enumerated set of file deletes/edits.
+
+**Architecture:** Variant A from the spec — orchestrator backend talks to a new HTTP provisioning endpoint on the corelink-server (no WSS admin protocol speaking). One workspace per deployment (`workflow_<deploy_id>`). Both `--mode corelink` (default) and `--mode relay` exist in new Node sender/receiver scripts. Corelink-aware code is isolated in named files (`corelink_admin.py`, `corelink-transport.js`, `plugins/corelink_demo/`).
+
+**Tech Stack:**
+- corelink-server: Node 16+, `https.createServer` + `knex` + sqlite3 (already in repo)
+- Backend: FastAPI, Python 3.11+, `httpx`, `pytest`/`pytest-asyncio` (already in deps)
+- Plugin: Python 3.11-slim Docker image with `corelink` PyPI + `fastapi`/`uvicorn`
+- Scripts: Node 16+, `@corelinkhub/corelink-client` (a.k.a. `corelink.lib.js`)
+
+**Spec:** `docs/superpowers/specs/2026-04-27-corelink-modular-demo-design.md`
+
+**Repos involved:**
+- `/Users/kaikaidu/Documents/GitHub/exp-orchestrator` (this repo) — backend, plugins, scripts, docs
+- `/Users/kaikaidu/documents/github/corelink-server` — provisioning routes added here
+
+---
+
+## Phase 1 — corelink-server provisioning routes
+
+Foundation for everything downstream. Implements the HTTP API the orchestrator backend will call.
+
+### Task 1: Add JSON-body helper and route skeleton on corelink-server
+
+**Files:**
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/corelink.js` (around line 4562)
+- Create: `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`:
+
+```js
+// Standalone test: requires corelink-server to be running on :20012.
+// Run: node tests/test-provision.js
+const https = require('https')
+
+const HOST = process.env.CL_HOST || '127.0.0.1'
+const PORT = parseInt(process.env.CL_PORT || '20012', 10)
+const TOKEN = process.env.CL_PROVISION_TOKEN || 'test-token'
+
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : ''
+    const req = https.request({
+      host: HOST, port: PORT, method, path,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data),
+        'X-Provision-Token': TOKEN,
+      },
+      rejectUnauthorized: false,
+    }, (res) => {
+      let chunks = ''
+      res.on('data', (c) => { chunks += c })
+      res.on('end', () => resolve({ status: res.statusCode, body: chunks }))
+    })
+    req.on('error', reject)
+    if (data) req.write(data)
+    req.end()
+  })
+}
+
+async function main() {
+  // Skeleton check: route exists, returns 200 (full behavior added in later tasks)
+  const res = await request('POST', '/api/provision', { deploy_id: 'test1234' })
+  console.log('POST /api/provision →', res.status, res.body)
+  if (res.status !== 200) {
+    console.error('FAIL: expected 200')
+    process.exit(1)
+  }
+  console.log('PASS')
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+- [ ] **Step 2: Run the test against the unchanged server to verify it fails**
+
+Run (in a separate terminal, start corelink-server first):
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+npm start &
+sleep 2
+node tests/test-provision.js
+```
+Expected: non-200 status (likely a static-file 404 or connection drop). Stop the server (`fg`, Ctrl-C) before continuing.
+
+- [ ] **Step 3: Add JSON-body helper + route dispatcher**
+
+In `/Users/kaikaidu/documents/github/corelink-server/corelink.js`, find the existing `httpsControlServer` callback (around line 4562). Replace its body to add a top-level dispatcher for `/api/*`:
+
+Locate this block:
+```js
+  const httpsControlServer = https.createServer(httpsOptions, (req, res) => {
+    if (req.url === '/version') {
+      res.writeHead(200)
+      res.end(`Corelink Server ${serverVersion}`)
+    } else {
+      log.info(`${req.socket.remoteAddress} ${req.method} ${req.url}`)
+      req.addListener('end', () => {
+        fileServer.serve(req, res)
+      }).resume()
+    }
+  })
+```
+
+Replace with:
+```js
+  // Helper: read full request body, parse as JSON. Resolves to {} for empty body.
+  function readJsonBody(req) {
+    return new Promise((resolve, reject) => {
+      let chunks = ''
+      req.on('data', (c) => { chunks += c })
+      req.on('end', () => {
+        if (!chunks) return resolve({})
+        try { resolve(JSON.parse(chunks)) } catch (e) { reject(e) }
+      })
+      req.on('error', reject)
+    })
+  }
+
+  function sendJson(res, status, body) {
+    const text = JSON.stringify(body)
+    res.writeHead(status, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(text),
+    })
+    res.end(text)
+  }
+
+  const httpsControlServer = https.createServer(httpsOptions, async (req, res) => {
+    if (req.url === '/version') {
+      res.writeHead(200)
+      res.end(`Corelink Server ${serverVersion}`)
+      return
+    }
+    if (req.url && req.url.startsWith('/api/')) {
+      try {
+        await handleApi(req, res)
+      } catch (e) {
+        log.error(e, 'api handler error')
+        sendJson(res, 500, { error: 'internal_error', detail: String(e) })
+      }
+      return
+    }
+    log.info(`${req.socket.remoteAddress} ${req.method} ${req.url}`)
+    req.addListener('end', () => {
+      fileServer.serve(req, res)
+    }).resume()
+  })
+
+  // Skeleton: returns 200 unconditionally for now. Auth + handlers added in next tasks.
+  async function handleApi(req, res) {
+    sendJson(res, 200, { skeleton: true })
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it now passes**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+npm start &
+sleep 2
+node tests/test-provision.js
+```
+Expected: `POST /api/provision → 200 {"skeleton":true}` then `PASS`. Kill the server (`fg`, Ctrl-C).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+git add corelink.js tests/test-provision.js
+git commit -m "Add /api dispatcher skeleton on httpsControlServer"
+```
+
+---
+
+### Task 2: Add token authentication to /api routes
+
+**Files:**
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/corelink.js` (`handleApi` function)
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`
+
+- [ ] **Step 1: Extend the test**
+
+Replace the `main()` function in `tests/test-provision.js` with:
+
+```js
+async function main() {
+  // 1. Missing token → 401
+  let res = await new Promise((resolve, reject) => {
+    const req = https.request({
+      host: HOST, port: PORT, method: 'POST', path: '/api/provision',
+      headers: { 'Content-Type': 'application/json' },
+      rejectUnauthorized: false,
+    }, (r) => {
+      let c = ''; r.on('data', (x) => { c += x }); r.on('end', () => resolve({ status: r.statusCode, body: c }))
+    })
+    req.on('error', reject)
+    req.write(JSON.stringify({ deploy_id: 'test1234' }))
+    req.end()
+  })
+  console.log('no token →', res.status)
+  if (res.status !== 401) { console.error('FAIL: expected 401, got', res.status); process.exit(1) }
+
+  // 2. Wrong token → 401
+  res = await request('POST', '/api/provision', { deploy_id: 'test1234' })
+  // overwrite token for this call only by using request() with a temporary env override
+  const wrongTokenRes = await new Promise((resolve, reject) => {
+    const req = https.request({
+      host: HOST, port: PORT, method: 'POST', path: '/api/provision',
+      headers: { 'Content-Type': 'application/json', 'X-Provision-Token': 'wrong' },
+      rejectUnauthorized: false,
+    }, (r) => {
+      let c = ''; r.on('data', (x) => { c += x }); r.on('end', () => resolve({ status: r.statusCode, body: c }))
+    })
+    req.on('error', reject)
+    req.write(JSON.stringify({ deploy_id: 'test1234' }))
+    req.end()
+  })
+  console.log('wrong token →', wrongTokenRes.status)
+  if (wrongTokenRes.status !== 401) { console.error('FAIL: wrong token should give 401'); process.exit(1) }
+
+  // 3. Correct token → 200 (skeleton still returns {skeleton: true})
+  const ok = await request('POST', '/api/provision', { deploy_id: 'test1234' })
+  console.log('correct token →', ok.status, ok.body)
+  if (ok.status !== 200) { console.error('FAIL: correct token should give 200'); process.exit(1) }
+
+  console.log('PASS')
+}
+```
+
+- [ ] **Step 2: Run the test, expect it to fail**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: `no token → 200` then FAIL (the skeleton accepts everything). Kill server.
+
+- [ ] **Step 3: Add token check to `handleApi`**
+
+In `corelink.js`, replace the skeleton `handleApi` with:
+
+```js
+  const PROVISION_TOKEN = process.env.CL_PROVISION_TOKEN || ''
+
+  async function handleApi(req, res) {
+    if (!PROVISION_TOKEN) {
+      return sendJson(res, 503, { error: 'provisioning_disabled',
+        detail: 'CL_PROVISION_TOKEN env var not set on corelink-server' })
+    }
+    if (req.headers['x-provision-token'] !== PROVISION_TOKEN) {
+      return sendJson(res, 401, { error: 'unauthorized' })
+    }
+    // Delegate to per-route handlers (added in next tasks)
+    return sendJson(res, 200, { authenticated: true })
+  }
+```
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: `no token → 401`, `wrong token → 401`, `correct token → 200`, then `PASS`. Kill server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+git add corelink.js tests/test-provision.js
+git commit -m "Add X-Provision-Token auth to /api routes"
+```
+
+---
+
+### Task 3: Implement POST /api/provision happy path
+
+**Files:**
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/corelink.js`
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`
+
+- [ ] **Step 1: Replace test main() with happy-path assertion**
+
+Update `main()` in `tests/test-provision.js`:
+
+```js
+async function main() {
+  const deployId = `t${Date.now()}`
+  const res = await request('POST', '/api/provision', { deploy_id: deployId })
+  console.log('POST →', res.status, res.body)
+  if (res.status !== 200) { console.error('FAIL: expected 200'); process.exit(1) }
+  const body = JSON.parse(res.body)
+  if (body.workspace !== `workflow_${deployId}`) { console.error('FAIL: workspace name'); process.exit(1) }
+  if (!body.host || !body.port) { console.error('FAIL: missing host/port'); process.exit(1) }
+  if (body.username !== 'Testuser' || body.password !== 'Testpassword') {
+    console.error('FAIL: expected Testuser/Testpassword'); process.exit(1)
+  }
+  console.log('PASS')
+}
+```
+
+- [ ] **Step 2: Run the test, expect it to fail**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: 200 but body is `{authenticated: true}` — FAIL on workspace check. Kill server.
+
+- [ ] **Step 3: Implement provisioning logic**
+
+In `corelink.js`, replace `handleApi` with the routing version:
+
+```js
+  const PROVISION_TOKEN = process.env.CL_PROVISION_TOKEN || ''
+  const DEMO_USERNAME = process.env.CL_DEMO_USERNAME || 'Testuser'
+  const DEMO_PASSWORD = process.env.CL_DEMO_PASSWORD || 'Testpassword'
+
+  async function handleApi(req, res) {
+    if (!PROVISION_TOKEN) {
+      return sendJson(res, 503, { error: 'provisioning_disabled',
+        detail: 'CL_PROVISION_TOKEN env var not set on corelink-server' })
+    }
+    if (req.headers['x-provision-token'] !== PROVISION_TOKEN) {
+      return sendJson(res, 401, { error: 'unauthorized' })
+    }
+
+    // Routing
+    const url = req.url || ''
+    if (req.method === 'POST' && url === '/api/provision') {
+      return handleProvision(req, res)
+    }
+    // DELETE handled in next task
+    return sendJson(res, 404, { error: 'not_found' })
+  }
+
+  async function handleProvision(req, res) {
+    let body
+    try {
+      body = await readJsonBody(req)
+    } catch (e) {
+      return sendJson(res, 400, { error: 'invalid_json', detail: String(e) })
+    }
+    const deployId = body.deploy_id
+    if (!deployId || typeof deployId !== 'string' || !/^[A-Za-z0-9_-]+$/.test(deployId)) {
+      return sendJson(res, 400, { error: 'invalid_deploy_id',
+        detail: 'deploy_id must be an alphanumeric/dash/underscore string' })
+    }
+    const workspaceName = `workflow_${deployId}`
+
+    // Look up the seeded admin user once, use as owner.
+    const admin = await knex('users').first('id').where('username', 'admin').catch(() => null)
+    if (!admin) {
+      return sendJson(res, 500, { error: 'no_admin_user',
+        detail: 'admin user not seeded on corelink-server' })
+    }
+
+    // Check existing workspace (idempotent on repeat).
+    const existing = await knex('workspaces')
+      .first('id').where('workspace_name', workspaceName).catch(() => null)
+    if (!existing) {
+      await knex('workspaces').insert({ owner_id: admin.id, workspace_name: workspaceName })
+      // Mirror the in-memory legacy structure addWorkspace maintains
+      if (typeof workspaces[workspaceName] === 'undefined') {
+        workspaces[workspaceName] = []
+        workspaces[workspaceName].owner = admin.id
+        workspaces[workspaceName].users = [admin.id]
+      }
+    }
+
+    // Determine the public host the orchestrator should hand to clients.
+    const publicHost = process.env.CL_PUBLIC_HOST || req.socket.localAddress || '127.0.0.1'
+    const publicPort = WSControl
+
+    return sendJson(res, 200, {
+      workspace: workspaceName,
+      host: publicHost,
+      port: publicPort,
+      username: DEMO_USERNAME,
+      password: DEMO_PASSWORD,
+    })
+  }
+```
+
+Note: `WSControl` and `workspaces` are existing in-scope variables in this function. `knex` is the module-level imported instance.
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: `POST → 200 {"workspace":"workflow_t…","host":"…","port":20012,"username":"Testuser","password":"Testpassword"}` then `PASS`. Kill server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+git add corelink.js tests/test-provision.js
+git commit -m "Implement POST /api/provision (workspace creation, admin-owned)"
+```
+
+---
+
+### Task 4: Make POST /api/provision idempotent
+
+**Files:**
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`
+
+(The handler in Task 3 already short-circuits when the workspace exists, so this is a verification task — no production code changes needed if the existing-row check works.)
+
+- [ ] **Step 1: Add idempotency assertion to test**
+
+Append to `main()` after the first happy-path block:
+
+```js
+  // Idempotency: second call with same deploy_id returns the same blob, status 200
+  const res2 = await request('POST', '/api/provision', { deploy_id: deployId })
+  console.log('POST (repeat) →', res2.status, res2.body)
+  if (res2.status !== 200) { console.error('FAIL: repeat should be 200'); process.exit(1) }
+  const body2 = JSON.parse(res2.body)
+  if (body2.workspace !== body.workspace) { console.error('FAIL: workspace mismatch'); process.exit(1) }
+```
+
+- [ ] **Step 2: Run the test, expect PASS without code changes**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: PASS (the `existing` check in handler already short-circuits). Kill server.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+git add tests/test-provision.js
+git commit -m "Verify POST /api/provision idempotency"
+```
+
+---
+
+### Task 5: Implement DELETE /api/provision/:deploy_id
+
+**Files:**
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/corelink.js`
+- Modify: `/Users/kaikaidu/documents/github/corelink-server/tests/test-provision.js`
+
+- [ ] **Step 1: Add DELETE happy-path + 404 idempotency to test**
+
+Append to `main()`:
+
+```js
+  // DELETE: success on existing
+  const del = await request('DELETE', `/api/provision/${deployId}`, null)
+  console.log('DELETE →', del.status)
+  if (del.status !== 200) { console.error('FAIL: expected 200'); process.exit(1) }
+
+  // DELETE: 200 (treated as success on already-gone)
+  const del2 = await request('DELETE', `/api/provision/${deployId}`, null)
+  console.log('DELETE (repeat) →', del2.status)
+  if (del2.status !== 200 && del2.status !== 404) {
+    console.error('FAIL: expected 200 or 404'); process.exit(1)
+  }
+```
+
+Also update `request()` to handle a `null` body cleanly — replace its body block with:
+
+```js
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : ''
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Provision-Token': TOKEN,
+    }
+    if (data) headers['Content-Length'] = Buffer.byteLength(data)
+    const req = https.request({
+      host: HOST, port: PORT, method, path, headers,
+      rejectUnauthorized: false,
+    }, (res) => {
+      let chunks = ''
+      res.on('data', (c) => { chunks += c })
+      res.on('end', () => resolve({ status: res.statusCode, body: chunks }))
+    })
+    req.on('error', reject)
+    if (data) req.write(data)
+    req.end()
+  })
+}
+```
+
+- [ ] **Step 2: Run the test, expect it to fail**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: DELETE returns 404 (the route handler returns `not_found` for unknown methods). Kill server.
+
+- [ ] **Step 3: Implement DELETE handler**
+
+In `handleApi`, add a DELETE branch before the final `not_found` return:
+
+```js
+    if (req.method === 'DELETE' && /^\/api\/provision\/[A-Za-z0-9_-]+$/.test(url)) {
+      return handleUnprovision(req, res)
+    }
+```
+
+Then add the handler function (next to `handleProvision`):
+
+```js
+  async function handleUnprovision(req, res) {
+    const url = req.url || ''
+    const deployId = url.replace('/api/provision/', '')
+    const workspaceName = `workflow_${deployId}`
+
+    const existing = await knex('workspaces')
+      .first('id').where('workspace_name', workspaceName).catch(() => null)
+    if (!existing) {
+      // Treat as success (idempotent). 200 keeps the contract simple for the orchestrator.
+      return sendJson(res, 200, { workspace: workspaceName, removed: false, reason: 'not_found' })
+    }
+    await knex('workspaces').where('id', existing.id).delete()
+    delete workspaces[workspaceName]
+    return sendJson(res, 200, { workspace: workspaceName, removed: true })
+  }
+```
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token npm start &
+sleep 2
+CL_PROVISION_TOKEN=test-token node tests/test-provision.js
+```
+Expected: full PASS through DELETE + repeat. Kill server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+git add corelink.js tests/test-provision.js
+git commit -m "Implement DELETE /api/provision/:deploy_id (idempotent)"
+```
+
+---
+
+## Phase 2 — backend `corelink_admin.py` HTTP client
+
+A thin async client over `httpx` that talks to the Phase 1 routes. All Corelink-specific provisioning logic lives in this one file; rip-out = delete the file.
+
+### Task 6: Create CorelinkAdminError + CorelinkProvisionResult dataclass
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/corelink_admin.py`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_corelink_admin.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_corelink_admin.py`:
+
+```python
+"""Unit tests for corelink_admin (mocked HTTP)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_provision_result_dataclass_shape():
+    from corelink_admin import CorelinkProvisionResult
+
+    r = CorelinkProvisionResult(
+        workspace="workflow_abc",
+        host="localhost",
+        port=20012,
+        username="Testuser",
+        password="Testpassword",
+    )
+    assert r.workspace == "workflow_abc"
+    assert r.port == 20012
+
+
+def test_admin_error_is_exception():
+    from corelink_admin import CorelinkAdminError
+
+    assert issubclass(CorelinkAdminError, Exception)
+```
+
+- [ ] **Step 2: Run the test, expect import failure**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: No module named 'corelink_admin'`.
+
+- [ ] **Step 3: Create the module skeleton**
+
+Create `backend/corelink_admin.py`:
+
+```python
+"""HTTP client for the corelink-server provisioning routes.
+
+All Corelink-specific deploy-time logic lives here. Removing this file is
+step 1 of ripping Corelink out of the backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class CorelinkAdminError(Exception):
+    """Raised when provisioning/unprovisioning a deployment fails."""
+
+
+@dataclass
+class CorelinkProvisionResult:
+    workspace: str
+    host: str
+    port: int
+    username: str
+    password: str
+```
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/corelink_admin.py backend/tests/test_corelink_admin.py
+git commit -m "Add corelink_admin types: CorelinkAdminError, CorelinkProvisionResult"
+```
+
+---
+
+### Task 7: Implement provision_deployment happy path
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/corelink_admin.py`
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_corelink_admin.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_corelink_admin.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_provision_deployment_happy_path(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+        @property
+        def text(self):
+            import json
+            return json.dumps(self._payload)
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return FakeResponse(200, {
+                "workspace": "workflow_abc12345",
+                "host": "1.2.3.4",
+                "port": 20012,
+                "username": "Testuser",
+                "password": "Testpassword",
+            })
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {"AsyncClient": FakeAsyncClient}))
+
+    result = await ca.provision_deployment("abc12345")
+
+    assert result.workspace == "workflow_abc12345"
+    assert result.host == "1.2.3.4"
+    assert result.port == 20012
+    assert result.username == "Testuser"
+    assert captured["url"] == "https://localhost:20012/api/provision"
+    assert captured["json"] == {"deploy_id": "abc12345"}
+    assert captured["headers"]["X-Provision-Token"] == "secret"
+```
+
+- [ ] **Step 2: Run the test, expect AttributeError on `provision_deployment`**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py::test_provision_deployment_happy_path -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement provision_deployment**
+
+Append to `backend/corelink_admin.py`:
+
+```python
+import os
+
+import httpx
+
+_DEFAULT_TIMEOUT = 5.0
+
+
+def _server_url() -> str:
+    host = os.getenv("CORELINK_HOST")
+    port = os.getenv("CORELINK_PORT", "20012")
+    if not host:
+        raise CorelinkAdminError("CORELINK_HOST not set")
+    return f"https://{host}:{port}"
+
+
+def _provision_token() -> str:
+    token = os.getenv("CORELINK_PROVISION_TOKEN")
+    if not token:
+        raise CorelinkAdminError("CORELINK_PROVISION_TOKEN not set")
+    return token
+
+
+async def provision_deployment(deploy_id: str) -> CorelinkProvisionResult:
+    """POST /api/provision on corelink-server. Idempotent: server returns same blob on repeat."""
+    url = f"{_server_url()}/api/provision"
+    headers = {"X-Provision-Token": _provision_token(), "Content-Type": "application/json"}
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=_DEFAULT_TIMEOUT) as client:
+            resp = await client.post(url, json={"deploy_id": deploy_id}, headers=headers)
+    except httpx.HTTPError as e:
+        raise CorelinkAdminError(f"corelink unreachable: {e}") from e
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        raise CorelinkAdminError(f"corelink rejected provision token (HTTP {resp.status_code})")
+    if resp.status_code != 200:
+        raise CorelinkAdminError(f"provision failed: HTTP {resp.status_code} {resp.text}")
+
+    body = resp.json()
+    return CorelinkProvisionResult(
+        workspace=body["workspace"],
+        host=body["host"],
+        port=int(body["port"]),
+        username=body["username"],
+        password=body["password"],
+    )
+```
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/corelink_admin.py backend/tests/test_corelink_admin.py
+git commit -m "Implement provision_deployment HTTP client (happy path)"
+```
+
+---
+
+### Task 8: provision_deployment error paths (timeout, 401, 5xx)
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_corelink_admin.py`
+
+(Code already handles these — tests confirm behavior.)
+
+- [ ] **Step 1: Write three failing-path tests**
+
+Append to `backend/tests/test_corelink_admin.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_provision_deployment_timeout(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *args, **kwargs):
+            raise __import__("httpx").ConnectTimeout("timeout")
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+        "ConnectTimeout": ca.httpx.ConnectTimeout,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="corelink unreachable"):
+        await ca.provision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_unauthorized(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "wrong")
+
+    class FakeResponse:
+        status_code = 401
+        text = '{"error":"unauthorized"}'
+        def json(self): return {"error": "unauthorized"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="rejected provision token"):
+        await ca.provision_deployment("abc")
+
+
+@pytest.mark.asyncio
+async def test_provision_deployment_server_error(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeResponse:
+        status_code = 500
+        text = '{"error":"oops"}'
+        def json(self): return {"error": "oops"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def post(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    with pytest.raises(ca.CorelinkAdminError, match="HTTP 500"):
+        await ca.provision_deployment("abc")
+```
+
+- [ ] **Step 2: Run the tests, expect PASS (handler already covers these)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: 6 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/tests/test_corelink_admin.py
+git commit -m "Cover provision_deployment timeout/401/5xx error paths"
+```
+
+---
+
+### Task 9: Implement unprovision_deployment
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/corelink_admin.py`
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_corelink_admin.py`
+
+- [ ] **Step 1: Write failing tests for happy + 404**
+
+Append to `backend/tests/test_corelink_admin.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_unprovision_deployment_happy(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+        def json(self): return {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def delete(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    await ca.unprovision_deployment("abc12345")
+    assert captured["url"] == "https://localhost:20012/api/provision/abc12345"
+    assert captured["headers"]["X-Provision-Token"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_unprovision_deployment_404_is_success(monkeypatch):
+    import corelink_admin as ca
+
+    monkeypatch.setenv("CORELINK_HOST", "localhost")
+    monkeypatch.setenv("CORELINK_PORT", "20012")
+    monkeypatch.setenv("CORELINK_PROVISION_TOKEN", "secret")
+
+    class FakeResponse:
+        status_code = 404
+        text = "{}"
+        def json(self): return {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def delete(self, *a, **k): return FakeResponse()
+
+    monkeypatch.setattr(ca, "httpx", type("M", (), {
+        "AsyncClient": FakeAsyncClient,
+        "HTTPError": ca.httpx.HTTPError,
+    }))
+
+    # Should NOT raise
+    await ca.unprovision_deployment("abc")
+```
+
+- [ ] **Step 2: Run, expect failure (function not defined)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: 2 errors on `unprovision_deployment`.
+
+- [ ] **Step 3: Implement unprovision_deployment**
+
+Append to `backend/corelink_admin.py`:
+
+```python
+async def unprovision_deployment(deploy_id: str) -> None:
+    """DELETE /api/provision/<deploy_id>. Treats 200 and 404 as success."""
+    url = f"{_server_url()}/api/provision/{deploy_id}"
+    headers = {"X-Provision-Token": _provision_token()}
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=_DEFAULT_TIMEOUT) as client:
+            resp = await client.delete(url, headers=headers)
+    except httpx.HTTPError as e:
+        raise CorelinkAdminError(f"corelink unreachable: {e}") from e
+
+    if resp.status_code in (200, 404):
+        return
+    if resp.status_code in (401, 403):
+        raise CorelinkAdminError(f"corelink rejected provision token (HTTP {resp.status_code})")
+    raise CorelinkAdminError(f"unprovision failed: HTTP {resp.status_code} {resp.text}")
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_corelink_admin.py -v
+```
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/corelink_admin.py backend/tests/test_corelink_admin.py
+git commit -m "Implement unprovision_deployment (404 treated as success)"
+```
+
+---
+
+## Phase 3 — backend deployment.py changes
+
+Thread `deploy_id` and `workspace` into the planner. Inject `CORELINK_*` into plugin nodes' env_plan.
+
+### Task 10: Update existing test assertions for deploy-id-scoped workspace
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_deployment_planner.py`
+
+The existing test at line 64 asserts `workspace == "source_plugin-a_json_workspace"`. We're changing the scheme to `workflow_<deploy_id>`. Update assertions before changing code (TDD: make the test match the desired behavior, watch it fail, then change code).
+
+- [ ] **Step 1: Update the assertion**
+
+Open `backend/tests/test_deployment_planner.py`. Find:
+
+```python
+def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWorkflow) -> None:
+    first = deployment.deploy(linear_workflow, inject_env=False)
+    second = deployment.deploy(linear_workflow, inject_env=False)
+```
+
+Change the call to pass `deploy_id` and `workspace`:
+
+```python
+def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWorkflow) -> None:
+    first = deployment.deploy(linear_workflow, deploy_id="abc12345",
+                              workspace="workflow_abc12345", inject_env=False)
+    second = deployment.deploy(linear_workflow, deploy_id="abc12345",
+                               workspace="workflow_abc12345", inject_env=False)
+```
+
+Find:
+
+```python
+    assert first["credentials_by_node"]["source"]["out_creds"]["json"]["workspace"] == (
+        "source_plugin-a_json_workspace"
+    )
+```
+
+Replace with:
+
+```python
+    assert first["credentials_by_node"]["source"]["out_creds"]["json"]["workspace"] == (
+        "workflow_abc12345"
+    )
+    # Every credential in the plan uses the same deploy-scoped workspace
+    for node_creds in first["credentials_by_node"].values():
+        for stream_creds in (node_creds["in_creds"], node_creds["out_creds"]):
+            for cred in stream_creds.values():
+                assert cred["workspace"] == "workflow_abc12345"
+```
+
+Also find any other call sites of `deployment.deploy(` in the same file — update each to pass `deploy_id` and `workspace`. Use `grep -n "deployment.deploy(" backend/tests/test_deployment_planner.py` to find them.
+
+For tests that don't care about the workspace (rejection tests, etc.), pass `deploy_id="test"` and `workspace="workflow_test"`.
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_deployment_planner.py -v
+```
+Expected: FAIL with `TypeError: deploy() got an unexpected keyword argument 'deploy_id'`.
+
+- [ ] **Step 3: No code changes yet — this task is just the test update.**
+
+- [ ] **Step 4: Commit the test update on its own**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/tests/test_deployment_planner.py
+git commit -m "Update planner tests for deploy-id-scoped workspace naming"
+```
+
+---
+
+### Task 11: Modify deploy() to accept deploy_id + workspace; thread through credentials
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/deployment.py`
+
+- [ ] **Step 1: Update deploy() signature and credential generation**
+
+Open `backend/deployment.py`. Find:
+
+```python
+def generate_pub_sub_cred(
+    stream_type: str, src: DeployNode, dst: DeployNode
+) -> StreamCredential:
+    return StreamCredential(
+        workspace=f"{src.id}_{dst.id}_{stream_type}_workspace",
+        protocol="pubsub",
+        stream_id=f"{src.id}_{dst.id}_{stream_type}_stream",
+        data_type=stream_type,
+        metadata={},
+    )
+```
+
+Replace with:
+
+```python
+def generate_pub_sub_cred(
+    stream_type: str, src: DeployNode, dst: DeployNode, workspace: str
+) -> StreamCredential:
+    return StreamCredential(
+        workspace=workspace,
+        protocol="pubsub",
+        stream_id=f"{src.id}_{dst.id}_{stream_type}_stream",
+        data_type=stream_type,
+        metadata={},
+    )
+```
+
+Find:
+
+```python
+def process_workflow(edges: List[DeployEdge], nodes_by_id: Dict[str, DeployNode]) -> int:
+```
+
+Replace with:
+
+```python
+def process_workflow(
+    edges: List[DeployEdge], nodes_by_id: Dict[str, DeployNode], workspace: str
+) -> int:
+```
+
+Inside `process_workflow`, find:
+
+```python
+        cred = generate_pub_sub_cred(stream_type, src, dst)
+```
+
+Replace with:
+
+```python
+        cred = generate_pub_sub_cred(stream_type, src, dst, workspace)
+```
+
+Find:
+
+```python
+def deploy(workflow: DeployWorkflow, inject_env: bool = False) -> Dict[str, Any]:
+    nodes_by_id = {node.id: node.model_copy(deep=True) for node in workflow.nodes}
+```
+
+Replace with:
+
+```python
+def deploy(
+    workflow: DeployWorkflow,
+    deploy_id: str = "local",
+    workspace: str | None = None,
+    inject_env: bool = False,
+) -> Dict[str, Any]:
+    if workspace is None:
+        workspace = f"workflow_{deploy_id}"
+    nodes_by_id = {node.id: node.model_copy(deep=True) for node in workflow.nodes}
+```
+
+Find:
+
+```python
+    process_workflow(workflow.edges, nodes_by_id)
+```
+
+Replace with:
+
+```python
+    process_workflow(workflow.edges, nodes_by_id, workspace)
+```
+
+Find the `__main__` block at the bottom:
+
+```python
+if __name__ == "__main__":
+    example_workflow = DeployWorkflow(
+        ...
+    )
+    print(deploy(example_workflow, inject_env=False))
+```
+
+Update the call:
+
+```python
+    print(deploy(example_workflow, deploy_id="example", inject_env=False))
+```
+
+- [ ] **Step 2: Update the planner result to include deploy_id + workspace**
+
+In the same file, find:
+
+```python
+    return {
+        "node_count": len(nodes_by_id),
+        "edge_count": len(workflow.edges),
+        ...
+        "credentials_by_node": creds_by_node,
+    }
+```
+
+Add two fields at the top:
+
+```python
+    return {
+        "deploy_id": deploy_id,
+        "workspace": workspace,
+        "node_count": len(nodes_by_id),
+        "edge_count": len(workflow.edges),
+        ...
+        "credentials_by_node": creds_by_node,
+    }
+```
+
+- [ ] **Step 3: Run the planner tests, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_deployment_planner.py -v
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/deployment.py
+git commit -m "Thread deploy_id + workspace through deploy planner"
+```
+
+---
+
+### Task 12: Inject CORELINK_* env vars into plugin nodes' env_plan
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/deployment.py`
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_deployment_planner.py`
+
+- [ ] **Step 1: Write failing tests for the new behavior**
+
+Append to `backend/tests/test_deployment_planner.py`:
+
+```python
+def test_corelink_env_injected_for_plugins_only(linear_workflow: DeployWorkflow) -> None:
+    corelink = {
+        "host": "1.2.3.4",
+        "port": 20012,
+        "username": "Testuser",
+        "password": "Testpassword",
+    }
+    plan = deployment.deploy(
+        linear_workflow,
+        deploy_id="abc",
+        workspace="workflow_abc",
+        corelink_creds=corelink,
+        inject_env=False,
+    )
+    plugin_a = plan["env_plan"]["plugin-a"]
+    assert plugin_a["CORELINK_HOST"] == "1.2.3.4"
+    assert plugin_a["CORELINK_PORT"] == "20012"
+    assert plugin_a["CORELINK_USERNAME"] == "Testuser"
+    assert plugin_a["CORELINK_PASSWORD"] == "Testpassword"
+
+    # Sender/receiver nodes don't get plugin-only injection
+    # In the linear_workflow fixture there's no receiver, but plugin-b is type=plugin too.
+    # Just confirm no extraneous keys leaked.
+
+
+def test_corelink_env_omitted_when_creds_not_provided(linear_workflow: DeployWorkflow) -> None:
+    plan = deployment.deploy(
+        linear_workflow,
+        deploy_id="abc",
+        workspace="workflow_abc",
+        inject_env=False,
+    )
+    plugin_a = plan["env_plan"]["plugin-a"]
+    assert "CORELINK_HOST" not in plugin_a
+    assert "CORELINK_PASSWORD" not in plugin_a
+```
+
+- [ ] **Step 2: Run, expect failure (`corelink_creds` kwarg not accepted)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_deployment_planner.py::test_corelink_env_injected_for_plugins_only -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement injection**
+
+In `backend/deployment.py`, find:
+
+```python
+def deploy(
+    workflow: DeployWorkflow,
+    deploy_id: str = "local",
+    workspace: str | None = None,
+    inject_env: bool = False,
+) -> Dict[str, Any]:
+```
+
+Replace with:
+
+```python
+def deploy(
+    workflow: DeployWorkflow,
+    deploy_id: str = "local",
+    workspace: str | None = None,
+    corelink_creds: Dict[str, Any] | None = None,
+    inject_env: bool = False,
+) -> Dict[str, Any]:
+```
+
+Find the env_plan loop:
+
+```python
+    for node in deployment_queue:
+        env_vars = build_env_vars(node)
+        env_plan[node.id] = env_vars
+        image_name = fetch_image_name(node)
+```
+
+Insert a corelink injection step right after `env_vars = build_env_vars(node)` and before `env_plan[node.id] = env_vars`:
+
+```python
+    for node in deployment_queue:
+        env_vars = build_env_vars(node)
+        if corelink_creds and node.type == "plugin":
+            env_vars["CORELINK_HOST"] = str(corelink_creds["host"])
+            env_vars["CORELINK_PORT"] = str(corelink_creds["port"])
+            env_vars["CORELINK_USERNAME"] = str(corelink_creds["username"])
+            env_vars["CORELINK_PASSWORD"] = str(corelink_creds["password"])
+        env_plan[node.id] = env_vars
+        image_name = fetch_image_name(node)
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_deployment_planner.py -v
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/deployment.py backend/tests/test_deployment_planner.py
+git commit -m "Inject CORELINK_* env vars into plugin-node env_plan"
+```
+
+---
+
+## Phase 4 — backend main.py changes
+
+Wire provisioning into `/deploy/execute/v2`, surface corelink creds in `/credentials`, add `DELETE /deployments/{id}`, update allowlist + run.sh.
+
+### Task 13: Allowlist the corelink_demo image
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/config/allowed_images.json`
+
+- [ ] **Step 1: Update allowlist**
+
+Replace the contents of `backend/config/allowed_images.json` (currently `{}`):
+
+```json
+{
+  "corelink_demo:latest": {
+    "approved": true,
+    "added_by": "corelink-modular-demo",
+    "notes": "Demo plugin: subscribes to IN streams, transforms, publishes to OUT streams via Corelink."
+  }
+}
+```
+
+- [ ] **Step 2: Verify with the existing allowlist test**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_allowlist_executor.py -v
+```
+Expected: existing tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/config/allowed_images.json
+git commit -m "Allowlist corelink_demo:latest runtime image"
+```
+
+---
+
+### Task 14: Update run.sh env vars
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/run.sh`
+
+- [ ] **Step 1: Replace the env block**
+
+Open `backend/run.sh`. Find:
+
+```bash
+export CORELINK_HOST="${CORELINK_HOST:-host.docker.internal}"
+export CORELINK_PORT="${CORELINK_PORT:-20012}"
+export CORELINK_USERNAME="${CORELINK_USERNAME:-Testuser}"
+export CORELINK_PASSWORD="${CORELINK_PASSWORD:-Testpassword}"
+```
+
+Replace with:
+
+```bash
+# Corelink integration. Provisioning credentials come back from the corelink-server's
+# /api/provision response — we don't carry CORELINK_USERNAME/PASSWORD here.
+export CORELINK_HOST="${CORELINK_HOST:-host.docker.internal}"
+export CORELINK_PORT="${CORELINK_PORT:-20012}"
+export CORELINK_PROVISION_TOKEN="${CORELINK_PROVISION_TOKEN:-test-token}"
+```
+
+- [ ] **Step 2: Smoke-test the script syntax**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+bash -n run.sh && echo "syntax ok"
+```
+Expected: `syntax ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/run.sh
+git commit -m "Replace USERNAME/PASSWORD env with CORELINK_PROVISION_TOKEN in run.sh"
+```
+
+---
+
+### Task 15: Wire /deploy/execute/v2 to provisioning + add DELETE /deployments/{id}
+
+**Files:**
+- Modify: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/main.py`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend/tests/test_main_corelink.py`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Create `backend/tests/test_main_corelink.py`:
+
+```python
+"""Integration-style tests for /deploy/execute/v2 + DELETE /deployments/{id}.
+
+Mocks corelink_admin and the executor so these tests don't need Docker or a
+running Corelink server.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import corelink_admin
+import main as main_module
+from executors import ContainerStatus
+from executors.noop import NoopExecutor
+
+
+def _workflow_payload():
+    return {
+        "nodes": [
+            {"id": "src", "type": "sender", "out_streams": ["json"]},
+            {"id": "plg", "type": "plugin", "runtime": "corelink_demo:latest",
+             "in_streams": ["json"], "out_streams": ["json"]},
+            {"id": "rcv", "type": "receiver", "in_streams": ["json"]},
+        ],
+        "edges": [
+            {"source": "src", "target": "plg", "data": "json"},
+            {"source": "plg", "target": "rcv", "data": "json"},
+        ],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Mock provisioning
+    async def fake_provision(deploy_id):
+        return corelink_admin.CorelinkProvisionResult(
+            workspace=f"workflow_{deploy_id}",
+            host="1.2.3.4", port=20012,
+            username="Testuser", password="Testpassword",
+        )
+    async def fake_unprovision(deploy_id): return None
+
+    monkeypatch.setattr(corelink_admin, "provision_deployment", fake_provision)
+    monkeypatch.setattr(corelink_admin, "unprovision_deployment", fake_unprovision)
+    # Force noop executor (no Docker)
+    monkeypatch.setenv("EXECUTOR_BACKEND", "noop")
+
+    # Reset deployments dict between tests
+    main_module.deployments.clear()
+    return TestClient(main_module.app)
+
+
+def test_deploy_v2_provisions_workspace_and_returns_corelink_block(client):
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "deploy_id" in body
+    deploy_id = body["deploy_id"]
+    assert body["plan"]["workspace"] == f"workflow_{deploy_id}"
+
+    # Sender credentials response includes the new corelink block
+    cred = client.get(f"/deployments/{deploy_id}/credentials", params={"role": "sender"}).json()
+    assert cred["corelink"]["host"] == "1.2.3.4"
+    assert cred["corelink"]["port"] == 20012
+    assert cred["corelink"]["username"] == "Testuser"
+    assert cred["credentials"]["json"]["workspace"] == f"workflow_{deploy_id}"
+
+
+def test_deploy_v2_returns_503_when_provision_fails(client, monkeypatch):
+    async def boom(deploy_id):
+        raise corelink_admin.CorelinkAdminError("corelink unreachable: timeout")
+    monkeypatch.setattr(corelink_admin, "provision_deployment", boom)
+
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    assert resp.status_code == 503
+    assert "corelink unreachable" in resp.json()["detail"]
+
+
+def test_delete_deployment_unprovisions_and_removes(client):
+    resp = client.post("/deploy/execute/v2", json=_workflow_payload(),
+                       params={"executor": "noop", "inject_env": "false"})
+    deploy_id = resp.json()["deploy_id"]
+    assert deploy_id in main_module.deployments
+
+    del_resp = client.delete(f"/deployments/{deploy_id}")
+    assert del_resp.status_code == 200
+    assert deploy_id not in main_module.deployments
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_main_corelink.py -v
+```
+Expected: tests fail (no provisioning, no DELETE endpoint).
+
+- [ ] **Step 3: Update main.py**
+
+Open `backend/main.py`. At the top, add to the imports near `from corelink_health import …`:
+
+```python
+import corelink_admin
+```
+
+Find:
+
+```python
+@app.post("/deploy/execute/v2")
+async def deploy_and_execute_v2(
+    payload: DeployWorkflow, executor: str = "local", inject_env: bool = True
+):
+    """Plan deployment and execute containers via the pluggable executor abstraction."""
+    # Never inject env vars into Docker images when using noop executor
+    effective_inject = inject_env and executor != "noop"
+    try:
+        plan = deploy(payload, inject_env=effective_inject)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+```
+
+Replace the body up through the deploy call with:
+
+```python
+@app.post("/deploy/execute/v2")
+async def deploy_and_execute_v2(
+    payload: DeployWorkflow, executor: str = "local", inject_env: bool = True
+):
+    """Plan deployment and execute containers via the pluggable executor abstraction."""
+    # Mint the deploy_id up-front so it can be the workspace key
+    deploy_id = uuid.uuid4().hex[:8]
+
+    # Provision a Corelink workspace + creds for this deployment
+    try:
+        provisioning = await corelink_admin.provision_deployment(deploy_id)
+    except corelink_admin.CorelinkAdminError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    corelink_creds = {
+        "host": provisioning.host,
+        "port": provisioning.port,
+        "username": provisioning.username,
+        "password": provisioning.password,
+    }
+
+    effective_inject = inject_env and executor != "noop"
+    try:
+        plan = deploy(
+            payload,
+            deploy_id=deploy_id,
+            workspace=provisioning.workspace,
+            corelink_creds=corelink_creds,
+            inject_env=effective_inject,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+```
+
+Find the deploy_id line further down and remove the duplicate uuid call:
+
+```python
+    deploy_id = uuid.uuid4().hex[:8]
+    deployments[deploy_id] = {
+        "plan": plan,
+        "execution": results,
+        "workflow": payload.model_dump(),
+    }
+```
+
+Replace with:
+
+```python
+    deployments[deploy_id] = {
+        "plan": plan,
+        "execution": results,
+        "workflow": payload.model_dump(),
+        "provisioning": {
+            "workspace": provisioning.workspace,
+            "host": provisioning.host,
+            "port": provisioning.port,
+            "username": provisioning.username,
+            "password": provisioning.password,
+        },
+    }
+```
+
+Update the response dict:
+
+```python
+    return {
+        "message": "Deploy executed",
+        "deploy_id": deploy_id,
+        "plan": plan,
+        "execution": results,
+    }
+```
+
+Now find the `/deployments/{deploy_id}/credentials` endpoint and add the corelink block. Find:
+
+```python
+    return {
+        "deploy_id": deploy_id,
+        "role": role,
+        "node_id": node_id,
+        "credentials": stream_creds,
+    }
+```
+
+Replace with:
+
+```python
+    provisioning = dep.get("provisioning", {})
+    corelink_block = None
+    if provisioning:
+        corelink_block = {
+            "host": provisioning["host"],
+            "port": provisioning["port"],
+            "username": provisioning["username"],
+            "password": provisioning["password"],
+        }
+    return {
+        "deploy_id": deploy_id,
+        "role": role,
+        "node_id": node_id,
+        "corelink": corelink_block,
+        "credentials": stream_creds,
+    }
+```
+
+Add a new endpoint at the bottom of `main.py`:
+
+```python
+@app.delete("/deployments/{deploy_id}")
+async def delete_deployment(deploy_id: str):
+    """Stop containers, unprovision Corelink workspace, remove deployment record."""
+    if deploy_id not in deployments:
+        raise HTTPException(status_code=404, detail=f"Deployment '{deploy_id}' not found")
+
+    dep = deployments[deploy_id]
+    warnings: list[str] = []
+
+    # Stop running containers (best-effort)
+    ex = get_executor()
+    for status in dep.get("execution", []):
+        cid = status.get("container_id")
+        if not cid:
+            continue
+        try:
+            await ex.stop(cid)
+        except Exception as e:
+            warnings.append(f"stop {cid} failed: {e}")
+
+    # Unprovision Corelink workspace
+    try:
+        await corelink_admin.unprovision_deployment(deploy_id)
+    except corelink_admin.CorelinkAdminError as e:
+        warnings.append(f"unprovision failed: {e}")
+
+    deployments.pop(deploy_id, None)
+    return {"status": "deleted", "deploy_id": deploy_id, "warnings": warnings}
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest tests/test_main_corelink.py -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Run all backend tests for regressions**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+.venv/bin/pytest -v
+```
+Expected: all pass (modulo unrelated failures in tests that already failed before this work — note any).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add backend/main.py backend/tests/test_main_corelink.py
+git commit -m "Wire /deploy/execute/v2 to provisioning; add DELETE /deployments/{id}"
+```
+
+---
+
+## Phase 5 — corelink_demo plugin Docker image
+
+A new plugin image that mirrors `reference_plugin` but with a real transform.
+
+### Task 16: Create plugin source files (main.py, requirements, transform tests)
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo/main.py`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo/requirements.txt`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo/tests/test_transform.py`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo/pytest.ini`
+
+- [ ] **Step 1: Write the transform test**
+
+Create `plugins/corelink_demo/tests/test_transform.py`:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_transform_uppercases_text():
+    from main import _transform
+    assert _transform(b"hello world") == b"HELLO WORLD"
+
+
+def test_transform_handles_empty():
+    from main import _transform
+    assert _transform(b"") == b""
+
+
+def test_transform_passes_through_non_utf8():
+    from main import _transform
+    # Non-UTF-8 bytes pass through unchanged
+    assert _transform(b"\xff\xfe") == b"\xff\xfe"
+```
+
+- [ ] **Step 2: Create pytest config**
+
+Create `plugins/corelink_demo/pytest.ini`:
+
+```ini
+[pytest]
+testpaths = tests
+```
+
+- [ ] **Step 3: Run, expect import failure**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo
+python3 -m pytest tests/ -v
+```
+Expected: FAIL.
+
+- [ ] **Step 4: Create requirements.txt**
+
+Create `plugins/corelink_demo/requirements.txt`:
+
+```
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink
+```
+
+- [ ] **Step 5: Create main.py**
+
+Create `plugins/corelink_demo/main.py` (close clone of `reference_plugin/main.py` with a real transform):
+
+```python
+"""
+corelink_demo plugin.
+
+Subscribes to all IN_* streams, runs `_transform` on each message, publishes
+to all OUT_* streams. Mirrors plugins/reference_plugin/main.py — keep them
+in sync if reference_plugin's structure changes.
+
+This entire directory is part of the Corelink rip-out: deleting
+plugins/corelink_demo/ removes the plugin without affecting other code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+
+import corelink
+import uvicorn
+from fastapi import FastAPI
+
+_out_senders: dict[str, int] = {}
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.environ.get(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.environ.get(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+def _transform(data: bytes) -> bytes:
+    """Demo transform: uppercase UTF-8 text. Non-UTF-8 passes through."""
+    try:
+        return data.decode("utf-8").upper().encode("utf-8")
+    except UnicodeDecodeError:
+        return data
+
+
+async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
+    try:
+        result = _transform(data)
+    except Exception as e:
+        print(f"[demo-plugin] transform error: {e}")
+        return
+    for sid in _out_senders.values():
+        await corelink.send(sid, result)
+
+
+async def _corelink_loop() -> None:
+    host = os.environ.get("CORELINK_HOST", "")
+    port = int(os.environ.get("CORELINK_PORT", "20012"))
+    username = os.environ.get("CORELINK_USERNAME", "")
+    password = os.environ.get("CORELINK_PASSWORD", "")
+
+    if not (host and username and password):
+        print("[demo-plugin] CORELINK_HOST/USERNAME/PASSWORD not set — idle")
+        return
+
+    await corelink.connect(username, password, host, port)
+    print(f"[demo-plugin] Connected to Corelink at {host}:{port}")
+
+    await corelink.set_data_callback(_on_data)
+
+    in_streams = _parse_stream_env("IN_")
+    for stream_type, cfg in in_streams.items():
+        stream_ids = [cfg["stream_id"]] if cfg["stream_id"] else []
+        await corelink.create_receiver(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+            stream_ids=stream_ids,
+            alert=True,
+        )
+        print(f"[demo-plugin] Receiver ready: {stream_type} @ {cfg['workspace']}")
+
+    out_streams = _parse_stream_env("OUT_")
+    for stream_type, cfg in out_streams.items():
+        sid = await corelink.create_sender(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+        )
+        _out_senders[stream_type] = sid
+        print(f"[demo-plugin] Sender ready: {stream_type} @ {cfg['workspace']} (sid={sid})")
+
+    await asyncio.sleep(float("inf"))
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    print(f"[demo-plugin] NODE_ID={os.environ.get('NODE_ID', '')}")
+    task = asyncio.create_task(_corelink_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/run")
+def run_status():
+    return {
+        "node_id": os.environ.get("NODE_ID", ""),
+        "in_streams": _parse_stream_env("IN_"),
+        "out_streams": _parse_stream_env("OUT_"),
+        "out_sender_ids": _out_senders,
+        "corelink_connected": bool(_out_senders),
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)
+```
+
+- [ ] **Step 6: Run transform tests, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo
+python3 -m pytest tests/ -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add plugins/corelink_demo/
+git commit -m "Add corelink_demo plugin: source, transform tests, requirements"
+```
+
+---
+
+### Task 17: Create plugin Dockerfile and build the image
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo/Dockerfile`
+
+- [ ] **Step 1: Create Dockerfile**
+
+Create `plugins/corelink_demo/Dockerfile`:
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+
+EXPOSE 8080
+
+CMD ["python", "main.py"]
+```
+
+- [ ] **Step 2: Build the image**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/plugins/corelink_demo
+docker build -t corelink_demo:latest .
+```
+Expected: image builds successfully. (Requires Docker daemon running.)
+
+- [ ] **Step 3: Verify image is tagged**
+
+```bash
+docker image inspect corelink_demo:latest --format '{{.Id}}' | head -c 30
+```
+Expected: a sha256 prefix.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add plugins/corelink_demo/Dockerfile
+git commit -m "Add Dockerfile for corelink_demo plugin"
+```
+
+---
+
+## Phase 6 — Node sender/receiver scripts
+
+Modular scripts with two transports (corelink default, relay fallback). Corelink-touching code lives in one file (`lib/corelink-transport.js`).
+
+### Task 18: Initialize Node script package + relay-transport (TDD-first)
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/package.json`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/lib/relay-transport.js`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/lib/__tests__/relay-transport.test.js`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/.gitignore`
+
+- [ ] **Step 1: Create package.json**
+
+Create `scripts/package.json`:
+
+```json
+{
+  "name": "exp-orchestrator-scripts",
+  "version": "0.1.0",
+  "description": "Node sender/receiver scripts for the auto-connect demo",
+  "private": true,
+  "scripts": {
+    "test": "node --test lib/__tests__"
+  },
+  "dependencies": {
+    "@corelinkhub/corelink-client": "^5.1.2"
+  }
+}
+```
+
+Create `scripts/.gitignore`:
+
+```
+node_modules/
+.venv/
+```
+
+- [ ] **Step 2: Write the failing relay-transport test**
+
+Create `scripts/lib/__tests__/relay-transport.test.js`:
+
+```js
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+test('relay-transport exports the expected interface', () => {
+  const t = require('../relay-transport')
+  assert.equal(typeof t.connect, 'function')
+  assert.equal(typeof t.send, 'function')
+  assert.equal(typeof t.subscribe, 'function')
+  assert.equal(typeof t.close, 'function')
+})
+
+test('relay-transport.send POSTs to backend with the message', async () => {
+  const calls = []
+  const fakeFetch = async (url, opts) => {
+    calls.push({ url, opts })
+    return { ok: true, status: 200, json: async () => ({ status: 'ok', listeners: 1 }) }
+  }
+  const t = require('../relay-transport')
+  const handle = await t.connect({
+    host: 'http://localhost:8000',
+    deployId: 'abc',
+    role: 'sender',
+    credentials: {},
+    _fetch: fakeFetch,
+  })
+  await t.send(handle, 'hello')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'http://localhost:8000/deployments/abc/messages')
+  assert.deepEqual(JSON.parse(calls[0].opts.body), { data: 'hello' })
+})
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+npm install --silent
+npm test 2>&1 | tail -20
+```
+Expected: tests fail (`relay-transport` not found).
+
+- [ ] **Step 4: Implement relay-transport**
+
+Create `scripts/lib/relay-transport.js`:
+
+```js
+/**
+ * Relay transport — sends/subscribes via the orchestrator backend's HTTP/SSE
+ * endpoints. No Corelink dependency; this is the long-term path that remains
+ * after Corelink is ripped out.
+ */
+
+const httpStream = require('http')
+const httpsStream = require('https')
+
+async function connect({ host, deployId, role, credentials, _fetch = globalThis.fetch }) {
+  return { host, deployId, role, _fetch }
+}
+
+async function send(handle, message) {
+  const url = `${handle.host}/deployments/${handle.deployId}/messages`
+  const resp = await handle._fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: message }),
+  })
+  if (!resp.ok) {
+    throw new Error(`relay POST failed: ${resp.status}`)
+  }
+  return resp.json()
+}
+
+async function subscribe(handle, onMessage) {
+  // Stream Server-Sent Events from /deployments/{id}/messages.
+  const url = new URL(`${handle.host}/deployments/${handle.deployId}/messages`)
+  const isHttps = url.protocol === 'https:'
+  const lib = isHttps ? httpsStream : httpStream
+  return new Promise((resolve, reject) => {
+    const req = lib.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`relay subscribe failed: ${res.statusCode}`))
+        return
+      }
+      let buffer = ''
+      res.on('data', (chunk) => {
+        buffer += chunk.toString('utf-8')
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            try {
+              const payload = JSON.parse(line.slice(6))
+              if (payload.message != null) onMessage(payload.message)
+            } catch { /* ignore malformed line */ }
+          }
+        }
+      })
+      res.on('end', () => resolve(() => req.destroy()))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    // Resolve immediately with an unsubscribe — caller blocks elsewhere
+    setImmediate(() => resolve(() => req.destroy()))
+  })
+}
+
+async function close(handle) { /* nothing to close on relay side */ }
+
+module.exports = { connect, send, subscribe, close }
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+npm test 2>&1 | tail -20
+```
+Expected: 2 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add scripts/package.json scripts/.gitignore scripts/lib/relay-transport.js scripts/lib/__tests__/
+git commit -m "Add Node scripts package + relay-transport with tests"
+```
+
+---
+
+### Task 19: Implement corelink-transport.js
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/lib/corelink-transport.js`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/lib/__tests__/interface.test.js`
+
+- [ ] **Step 1: Write an interface conformance test**
+
+Create `scripts/lib/__tests__/interface.test.js`:
+
+```js
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+test('corelink-transport exports the same shape as relay-transport', () => {
+  const corelink = require('../corelink-transport')
+  const relay = require('../relay-transport')
+  for (const fn of ['connect', 'send', 'subscribe', 'close']) {
+    assert.equal(typeof corelink[fn], 'function', `corelink-transport missing ${fn}`)
+    assert.equal(typeof relay[fn], 'function', `relay-transport missing ${fn}`)
+  }
+})
+```
+
+- [ ] **Step 2: Run, expect failure (corelink-transport missing)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+npm test 2>&1 | tail -20
+```
+Expected: FAIL on the new test.
+
+- [ ] **Step 3: Implement corelink-transport.js**
+
+Create `scripts/lib/corelink-transport.js`:
+
+```js
+/**
+ * Corelink transport — wraps @corelinkhub/corelink-client.
+ *
+ * This file is the ONLY place in scripts/ that imports `corelink`.
+ * Deleting this file (and removing the require() ternary in sender.js/receiver.js)
+ * is the rip-out path.
+ */
+
+const corelink = require('@corelinkhub/corelink-client')
+
+async function connect({ host, deployId, role, credentials, corelinkBlock }) {
+  if (!corelinkBlock) {
+    throw new Error('corelink block missing from credentials response')
+  }
+  await corelink.connect(
+    { username: corelinkBlock.username, password: corelinkBlock.password },
+    { ControlIP: corelinkBlock.host, ControlPort: corelinkBlock.port },
+  )
+
+  const streamTypes = Object.keys(credentials || {})
+  if (streamTypes.length === 0) {
+    throw new Error(`no ${role} credentials found in deployment ${deployId}`)
+  }
+  const streamType = streamTypes[0]
+  const cred = credentials[streamType]
+
+  if (role === 'sender') {
+    const sendId = await corelink.createSender({
+      workspace: cred.workspace,
+      protocol: 'ws',
+      type: cred.data_type,
+    })
+    return { role, sendId, cred, streamType }
+  }
+  // receiver
+  return { role, cred, streamType }
+}
+
+async function send(handle, message) {
+  if (handle.role !== 'sender') throw new Error('send() called on non-sender handle')
+  await corelink.send(handle.sendId, Buffer.from(message, 'utf-8'))
+}
+
+async function subscribe(handle, onMessage) {
+  if (handle.role !== 'receiver') throw new Error('subscribe() called on non-receiver handle')
+  corelink.on('receiver', async (data) => {
+    const streamIDs = [data.streamID]
+    await corelink.subscribe({ streamIDs })
+  })
+  corelink.on('data', (streamID, data) => {
+    onMessage(data.toString('utf-8'))
+  })
+  await corelink.createReceiver({
+    workspace: handle.cred.workspace,
+    streamIDs: handle.cred.stream_id ? [handle.cred.stream_id] : [],
+    type: handle.cred.data_type,
+    protocol: 'ws',
+    alert: true,
+  })
+  return async () => { await corelink.exit() }
+}
+
+async function close(handle) {
+  await corelink.exit()
+}
+
+module.exports = { connect, send, subscribe, close }
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+npm test 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add scripts/lib/corelink-transport.js scripts/lib/__tests__/interface.test.js
+git commit -m "Add corelink-transport.js (modular Corelink wrapper)"
+```
+
+---
+
+### Task 20: Implement sender.js CLI
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/sender.js`
+
+- [ ] **Step 1: Create sender.js**
+
+```js
+#!/usr/bin/env node
+/**
+ * Standalone sender that auto-connects via corelink (default) or relay.
+ * Usage: node sender.js <deploy_id> [--mode corelink|relay] [--host URL]
+ */
+
+const readline = require('readline')
+
+function parseArgs(argv) {
+  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const positional = []
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === '--mode') args.mode = argv[++i]
+    else if (a === '--host') args.host = argv[++i]
+    else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
+    else positional.push(a)
+  }
+  if (positional.length !== 1) {
+    console.error('usage: sender.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    process.exit(2)
+  }
+  args.deployId = positional[0]
+  return args
+}
+
+async function fetchCredentials(host, deployId, role) {
+  const url = `${host}/deployments/${deployId}/credentials?role=${role}`
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    console.error(`Error fetching credentials: ${resp.status} ${await resp.text()}`)
+    process.exit(1)
+  }
+  return resp.json()
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const transport = args.mode === 'corelink'
+    ? require('./lib/corelink-transport')
+    : require('./lib/relay-transport')
+
+  console.log(`Mode: ${args.mode}`)
+  const cred = await fetchCredentials(args.host, args.deployId, 'sender')
+
+  let handle
+  try {
+    handle = await transport.connect({
+      host: args.host,
+      deployId: args.deployId,
+      role: 'sender',
+      credentials: cred.credentials,
+      corelinkBlock: cred.corelink,
+    })
+  } catch (e) {
+    console.error(`Connect failed (${args.mode}): ${e.message}`)
+    if (args.mode === 'corelink') console.error('Try --mode relay as a fallback.')
+    process.exit(1)
+  }
+
+  console.log(`Sender connected (deployment: ${args.deployId})`)
+  console.log('Type messages to send (Ctrl+C to quit):\n')
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  rl.setPrompt('> ')
+  rl.prompt()
+  rl.on('line', async (line) => {
+    if (line) {
+      try {
+        await transport.send(handle, line)
+        console.log(`  sent: ${line}`)
+      } catch (e) {
+        console.error(`  send error: ${e.message}`)
+      }
+    }
+    rl.prompt()
+  })
+  rl.on('close', async () => {
+    await transport.close(handle).catch(() => {})
+    console.log('\nDone.')
+    process.exit(0)
+  })
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+- [ ] **Step 2: Verify it parses args**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+node sender.js 2>&1 | head -3
+```
+Expected: usage error message.
+
+```bash
+node sender.js --help 2>&1 | head -3
+```
+Expected: `unknown flag: --help`.
+
+- [ ] **Step 3: Verify imports load (without invoking corelink connect)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+node -e "require('./lib/corelink-transport'); require('./lib/relay-transport'); console.log('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add scripts/sender.js
+git commit -m "Add Node sender CLI (modular --mode corelink|relay)"
+```
+
+---
+
+### Task 21: Implement receiver.js CLI
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/receiver.js`
+
+- [ ] **Step 1: Create receiver.js**
+
+```js
+#!/usr/bin/env node
+/**
+ * Standalone receiver that auto-connects via corelink (default) or relay.
+ * Usage: node receiver.js <deploy_id> [--mode corelink|relay] [--host URL]
+ */
+
+function parseArgs(argv) {
+  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const positional = []
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === '--mode') args.mode = argv[++i]
+    else if (a === '--host') args.host = argv[++i]
+    else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
+    else positional.push(a)
+  }
+  if (positional.length !== 1) {
+    console.error('usage: receiver.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    process.exit(2)
+  }
+  args.deployId = positional[0]
+  return args
+}
+
+async function fetchCredentials(host, deployId, role) {
+  const url = `${host}/deployments/${deployId}/credentials?role=${role}`
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    console.error(`Error fetching credentials: ${resp.status} ${await resp.text()}`)
+    process.exit(1)
+  }
+  return resp.json()
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const transport = args.mode === 'corelink'
+    ? require('./lib/corelink-transport')
+    : require('./lib/relay-transport')
+
+  console.log(`Mode: ${args.mode}`)
+  const cred = await fetchCredentials(args.host, args.deployId, 'receiver')
+
+  let handle
+  try {
+    handle = await transport.connect({
+      host: args.host,
+      deployId: args.deployId,
+      role: 'receiver',
+      credentials: cred.credentials,
+      corelinkBlock: cred.corelink,
+    })
+  } catch (e) {
+    console.error(`Connect failed (${args.mode}): ${e.message}`)
+    if (args.mode === 'corelink') console.error('Try --mode relay as a fallback.')
+    process.exit(1)
+  }
+
+  console.log(`Receiver connected (deployment: ${args.deployId})`)
+  console.log('Listening for messages (Ctrl+C to quit)...\n')
+
+  await transport.subscribe(handle, (msg) => {
+    console.log(`[received] ${msg}`)
+  })
+
+  // Keep alive
+  process.on('SIGINT', async () => {
+    await transport.close(handle).catch(() => {})
+    console.log('\nDone.')
+    process.exit(0)
+  })
+  await new Promise(() => {})
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+- [ ] **Step 2: Verify it parses args**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+node receiver.js 2>&1 | head -3
+```
+Expected: usage error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add scripts/receiver.js
+git commit -m "Add Node receiver CLI (modular --mode corelink|relay)"
+```
+
+---
+
+### Task 22: Add shell wrappers run_sender.js.sh and run_receiver.js.sh
+
+**Files:**
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/run_sender.js.sh`
+- Create: `/Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts/run_receiver.js.sh`
+
+- [ ] **Step 1: Create run_sender.js.sh**
+
+```bash
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d node_modules ]; then
+  npm install --silent
+fi
+
+exec node sender.js "$@"
+```
+
+- [ ] **Step 2: Create run_receiver.js.sh**
+
+```bash
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d node_modules ]; then
+  npm install --silent
+fi
+
+exec node receiver.js "$@"
+```
+
+- [ ] **Step 3: Make them executable**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+chmod +x run_sender.js.sh run_receiver.js.sh
+./run_sender.js.sh 2>&1 | head -3
+```
+Expected: usage error from sender.js.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git add scripts/run_sender.js.sh scripts/run_receiver.js.sh
+git commit -m "Add npm-install + node wrapper scripts for Node sender/receiver"
+```
+
+---
+
+## Phase 7 — manual demo runbook + final verification
+
+Demo runbook lives in the spec; this phase verifies the end-to-end flow works against a live corelink-server. No new code — verification only.
+
+### Task 23: Run end-to-end verification (corelink mode)
+
+This is a manual smoke test. Mark each step `[x]` only after the expected outcome is observed.
+
+- [ ] **Step 1: Start the corelink-server**
+
+```bash
+cd /Users/kaikaidu/documents/github/corelink-server
+CL_PROVISION_TOKEN=test-token CL_PUBLIC_HOST=127.0.0.1 npm start
+```
+Expected: `ws control server listening 0.0.0.0:20012`. Leave running.
+
+- [ ] **Step 2: Start the orchestrator backend (new terminal)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/backend
+CORELINK_HOST=127.0.0.1 CORELINK_PORT=20012 CORELINK_PROVISION_TOKEN=test-token ./run.sh
+```
+Expected: uvicorn listening on :8000. Leave running.
+
+- [ ] **Step 3: Submit the demo workflow**
+
+Create a temp file `/tmp/demo-workflow.json`:
+
+```json
+{
+  "nodes": [
+    {"id": "src", "type": "sender", "out_streams": ["json"]},
+    {"id": "plg", "type": "plugin", "runtime": "corelink_demo:latest",
+     "in_streams": ["json"], "out_streams": ["json"]},
+    {"id": "rcv", "type": "receiver", "in_streams": ["json"]}
+  ],
+  "edges": [
+    {"source": "src", "target": "plg", "data": "json"},
+    {"source": "plg", "target": "rcv", "data": "json"}
+  ]
+}
+```
+
+Then:
+
+```bash
+curl -X POST 'http://localhost:8000/deploy/execute/v2?executor=local&inject_env=true' \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/demo-workflow.json
+```
+Expected: 200 with `{"deploy_id": "...", "plan": {"workspace": "workflow_..."}, "execution": [...]}`. Note the `deploy_id`.
+
+- [ ] **Step 4: Verify credentials endpoint includes corelink block**
+
+```bash
+curl -s "http://localhost:8000/deployments/<DEPLOY_ID>/credentials?role=sender" | python3 -m json.tool
+```
+Expected: response has both `corelink: {host, port, username, password}` and `credentials: {json: {workspace, ...}}`.
+
+- [ ] **Step 5: Run sender (new terminal)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+./run_sender.js.sh <DEPLOY_ID>
+```
+Expected: `Mode: corelink` then `Sender connected (deployment: <id>)` then prompt.
+
+- [ ] **Step 6: Run receiver (new terminal)**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator/scripts
+./run_receiver.js.sh <DEPLOY_ID>
+```
+Expected: `Mode: corelink` then `Receiver connected (deployment: <id>)` then `Listening for messages...`.
+
+- [ ] **Step 7: Send a message**
+
+In the sender terminal, type `hello` and Enter.
+Expected: receiver terminal prints `[received] HELLO`.
+
+- [ ] **Step 8: Cleanup**
+
+Ctrl-C the sender and receiver. Then:
+
+```bash
+curl -X DELETE "http://localhost:8000/deployments/<DEPLOY_ID>"
+```
+Expected: 200 with `{"status": "deleted", "deploy_id": "...", "warnings": []}`.
+
+- [ ] **Step 9: Verify workspace removed**
+
+```bash
+sqlite3 /Users/kaikaidu/documents/github/corelink-server/data/sqlite.db \
+  "SELECT workspace_name FROM workspaces WHERE workspace_name='workflow_<DEPLOY_ID>';"
+```
+Expected: empty result.
+
+(If the sqlite path differs, locate the configured `knexfile.js` to find it.)
+
+---
+
+### Task 24: Run end-to-end verification (relay mode)
+
+Confirm the relay path also still works (regression check).
+
+- [ ] **Step 1: Submit a fresh workflow** (corelink-server can be down for this; if so, set `CORELINK_PROVISION_TOKEN` to a bogus value and skip provisioning by temporarily commenting it — or restart with mocked provisioning. Easier: leave corelink-server up.)
+
+```bash
+curl -X POST 'http://localhost:8000/deploy/execute/v2?executor=noop&inject_env=false' \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/demo-workflow.json
+```
+Note the `deploy_id`.
+
+- [ ] **Step 2: Run sender + receiver in --mode relay**
+
+```bash
+# Terminal A
+./run_sender.js.sh <DEPLOY_ID> --mode relay
+# Terminal B
+./run_receiver.js.sh <DEPLOY_ID> --mode relay
+```
+
+- [ ] **Step 3: Send a message**
+
+Type `hello` in sender. Expected: receiver prints `[received] hello` (relay mode does NOT run plugin transforms unless plugins are configured in `apply_pipeline`; this is acceptable for the regression check).
+
+- [ ] **Step 4: Cleanup**
+
+Ctrl-C scripts. `curl -X DELETE` the deployment.
+
+---
+
+### Task 25: Final commit (no-op tag)
+
+- [ ] **Step 1: Verify the working tree is clean**
+
+```bash
+cd /Users/kaikaidu/Documents/GitHub/exp-orchestrator
+git status
+```
+Expected: clean working tree.
+
+- [ ] **Step 2: Tag the demo-ready state**
+
+```bash
+git tag corelink-demo-ready -m "End-to-end Corelink demo verified (sender → plugin → receiver)"
+git tag --list | grep corelink-demo
+```
+Expected: tag listed.
+
+---
+
+## Self-review checklist (post-plan)
+
+Spec coverage check (each spec section maps to at least one task):
+
+- [x] Spec §Architecture / §Data flow → Tasks 11, 12, 15
+- [x] Spec §Components: new files → Tasks 6, 16, 17, 18, 19, 20, 21, 22 + corelink-server tasks 1-5
+- [x] Spec §Components: rip-out checklist → covered by file-isolation discipline; not implemented as a task
+- [x] Spec §Interfaces: Node transport → Tasks 18, 19
+- [x] Spec §Interfaces: Python plugin → Task 16
+- [x] Spec §Interfaces: corelink_admin → Tasks 6-9
+- [x] Spec §Interfaces: corelink-server provisioning routes → Tasks 1-5
+- [x] Spec §Data flow: deploy → Task 15
+- [x] Spec §Data flow: credentials response (corelink block) → Task 15
+- [x] Spec §Data flow: cleanup → Task 15 (DELETE endpoint)
+- [x] Spec §Error handling: 503 on provision failure → Task 15 test
+- [x] Spec §Error handling: 401 token rejection → Tasks 2, 8
+- [x] Spec §Error handling: cleanup partial failure (warnings) → Task 15
+- [x] Spec §Testing: backend unit tests → Tasks 6-15
+- [x] Spec §Testing: corelink-server route tests → Tasks 1-5 (test-provision.js)
+- [x] Spec §Testing: Node interface conformance → Task 19
+- [x] Spec §Testing: plugin transform tests → Task 16
+- [x] Spec §Testing: manual demo runbook → Tasks 23-24
+
+No placeholders detected on review. Type names consistent across tasks: `CorelinkProvisionResult`, `CorelinkAdminError`, `provision_deployment(deploy_id)`, `unprovision_deployment(deploy_id)`, transport interface (`connect/send/subscribe/close`).

--- a/docs/superpowers/specs/2026-04-27-corelink-modular-demo-design.md
+++ b/docs/superpowers/specs/2026-04-27-corelink-modular-demo-design.md
@@ -1,0 +1,408 @@
+# Corelink-modular auto-connect demo — Design
+
+**Date**: 2026-04-27
+**Branch**: `demo-auto-connect-scripts`
+**Status**: Approved (brainstorming complete; awaiting implementation plan)
+
+## Problem
+
+The auto-connect sender/receiver demo currently flows through an HTTP/SSE
+relay in the orchestrator backend (`/deployments/{id}/messages`). For an
+upcoming presentation we want the demo to run end-to-end through a real
+Corelink server (`corelink.js`, the NYU pub/sub framework), with a plugin
+between sender and receiver. After the presentation we plan to remove
+Corelink entirely; everything added for the demo must therefore live behind
+a clean modular boundary so that ripping it out is a small, enumerated set
+of file deletes and edits — not a refactor.
+
+## Goals
+
+1. End-to-end demo over Corelink: `sender → plugin → receiver`, three
+   processes, all wire transport via Corelink pub/sub.
+2. The relay path (`--mode relay`) continues to work unchanged.
+3. Every file that imports or speaks Corelink is named, isolated, and
+   listed in a rip-out checklist.
+4. Per-deployment workspace isolation on Corelink (one workspace per
+   deploy, named `workflow_<deploy_id>`).
+5. The orchestrator backend does not speak the Corelink WSS admin protocol;
+   it talks to a new HTTP provisioning endpoint on the Corelink server.
+
+## Non-goals
+
+- Multi-transport abstraction long-term (we are not building a permanent
+  `Transport` interface; Corelink is going away).
+- Corelink reachability monitoring beyond what `corelink_health.py`
+  already does.
+- Plugin restart / reconnect resilience.
+- CI integration for Corelink end-to-end (manual runbook only).
+- Anything in the frontend / Convex layer.
+
+## Architecture
+
+Five processes participate in a demo run:
+
+```
+[corelink-server]   ←—— POST /api/provision (admin token) —— [backend (FastAPI)]
+       ↑                                                              ↑
+       │ wss://, testuser/testpassword                                │ HTTP
+       │                                                              │
+[sender.js]  ──pub──►  workspace_<deploy_id> stream:in  ──►  [plugin container]
+                                                                  │
+                                                                  │ pub
+                                                                  ▼
+                       workspace_<deploy_id> stream:out  ──►  [receiver.js]
+```
+
+Lifecycle:
+
+1. Operator submits a workflow (`sender → plugin → receiver`) to
+   `POST /deploy/execute/v2`.
+2. Backend mints `deploy_id`, calls `corelink_admin.provision_deployment`
+   which issues a single HTTPS `POST /api/provision` to the Corelink server.
+   Provisioning returns `{workspace, host, port, username, password}` —
+   that blob is the single source of truth for Corelink connection info.
+3. Backend runs the planner with the provisioned workspace. The planner's
+   `generate_pub_sub_cred` emits `StreamCredential` records using
+   `workspace_<deploy_id>`. `build_env_vars` emits `IN_*`/`OUT_*` triples
+   plus `CORELINK_HOST/PORT/USERNAME/PASSWORD` for plugin nodes only.
+4. Executor launches the plugin container with those env vars; the
+   container's `main.py` (mirroring `plugins/reference_plugin/main.py`)
+   connects to Corelink and wires its IN/OUT streams.
+5. Operator runs `node scripts/sender.js <deploy_id>` and
+   `node scripts/receiver.js <deploy_id>`. Each fetches credentials from
+   `GET /deployments/{id}/credentials?role=…` (returned shape gains a
+   `corelink: {host, port, username, password}` block) and connects via
+   `scripts/lib/corelink-transport.js`.
+6. Sender publishes → plugin transforms → receiver prints. Wire transport
+   is Corelink pubsub end to end.
+7. `DELETE /deployments/{deploy_id}` stops containers and calls
+   `corelink_admin.unprovision_deployment(deploy_id)`, which issues
+   `DELETE /api/provision/<id>` on the Corelink server.
+
+Both `--mode corelink` (default) and `--mode relay` exist in the new Node
+scripts. Relay mode reuses the existing backend `/deployments/{id}/messages`
+endpoints and never touches Corelink.
+
+## Components
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `scripts/sender.js` | Node sender CLI; `--mode corelink` (default) or `--mode relay`; `--corelink-host`, `--corelink-username` overrides |
+| `scripts/receiver.js` | Node receiver CLI; same flags |
+| `scripts/lib/corelink-transport.js` | All `corelink.lib.js` calls live here |
+| `scripts/lib/relay-transport.js` | HTTP/SSE fallback; same exported function shape as corelink-transport |
+| `scripts/package.json` | Pins `@corelinkhub/corelink-client` (or local file path to `corelink.lib.js`) |
+| `scripts/run_sender.js.sh`, `scripts/run_receiver.js.sh` | `npm install` + `node` wrappers |
+| `plugins/corelink_demo/Dockerfile` | New Python plugin image, `python:3.11-slim` base |
+| `plugins/corelink_demo/main.py` | Subscribe IN_*, run `_transform`, publish OUT_* (mirrors `reference_plugin`) |
+| `plugins/corelink_demo/requirements.txt` | `corelink`, `fastapi`, `uvicorn` |
+| `plugins/corelink_demo/tests/test_transform.py` | Pure-function test of `_transform` |
+| `backend/corelink_admin.py` | `provision_deployment(deploy_id, streams) -> CorelinkProvisionResult`, `unprovision_deployment(deploy_id)`. Thin HTTP client. |
+| `backend/tests/test_corelink_admin.py` | Mocks HTTP; covers happy path, timeout, bad-token, idempotency |
+
+### Files edited
+
+| Path | Change |
+|---|---|
+| `backend/main.py` | `/deploy/execute/v2` calls `provision_deployment` first; threads workspace+creds into planner; `/deployments/{id}/credentials` response gains `corelink` block; new `DELETE /deployments/{id}` endpoint |
+| `backend/deployment.py` | `deploy(workflow, deploy_id, workspace, inject_env)` signature gains `deploy_id` and `workspace`; `generate_pub_sub_cred` uses the deployment-scoped workspace; `build_env_vars` injects `CORELINK_*` vars for plugin nodes only (sourced from the provisioning blob, not `os.environ`) |
+| `backend/allowlist.py` | Add `corelink_demo:latest` to runtime image allowlist |
+| `backend/run.sh` | Add `CORELINK_PROVISION_TOKEN` (shared secret with the corelink server). Keep `CORELINK_HOST` / `CORELINK_PORT` (read by `corelink_admin` and `corelink_health`). Drop `CORELINK_USERNAME` / `CORELINK_PASSWORD` — they're returned by the provisioning response now and are not needed in the orchestrator process env. |
+| `corelink-server/corelink.js` | Extend `httpsControlServer` callback at `~:4562` with two new branches: `POST /api/provision` and `DELETE /api/provision/<deploy_id>`. Both gated by `X-Provision-Token` header. Both idempotent. |
+| `corelink-server/tests/tests.js` | Add provisioning route tests |
+
+### Rip-out checklist (for after the demo)
+
+**Delete:**
+- `backend/corelink_health.py`, `backend/corelink_admin.py`
+- `backend/tests/test_corelink_health.py`, `backend/tests/test_corelink_admin.py`
+- `plugins/corelink_demo/`, `plugins/reference_plugin/`
+- `scripts/lib/corelink-transport.js`
+- `scripts/package.json` corelink-client dependency line
+- The two `/api/provision` route branches in `corelink-server/corelink.js`
+  (and their tests in `tests/tests.js`)
+
+**Edit:**
+- `backend/main.py` — remove `/health/corelink` endpoint, the
+  `provision_deployment` call in `/deploy/execute/v2`, the
+  `unprovision_deployment` call in `DELETE /deployments/{id}`, the
+  `corelink_health` import, and remove corelink-related fields from
+  `deploy_with_allocation`. The `corelink` block in the credentials
+  response goes away.
+- `backend/allocator.py` — remove `corelink_health` import and the
+  `corelink_unreachable` defer branch.
+- `backend/deployment.py` — remove `CORELINK_*` injection in
+  `build_env_vars`; replace `generate_pub_sub_cred` body with a
+  relay-only credential (or drop it if relay needs none).
+- `backend/run.sh` — drop `CORELINK_*` env vars.
+- `scripts/sender.js`, `scripts/receiver.js` — remove `--mode corelink`
+  branch and the `require('./lib/corelink-transport')` ternary; only
+  `relay-transport` remains. Optionally remove the mode flag entirely.
+
+**Total**: ~7 files deleted, ~5 files edited.
+
+## Interfaces
+
+### Node transport interface
+
+Both `corelink-transport.js` and `relay-transport.js` export the same
+shape:
+
+```js
+module.exports = {
+  async connect({ host, deployId, role, credentials }) { /* → handle */ },
+  async send(handle, message) {},
+  async subscribe(handle, onMessage) { /* → unsubscribe fn */ },
+  async close(handle) {},
+};
+```
+
+`sender.js` / `receiver.js` pick by `--mode`:
+
+```js
+const transport = mode === 'corelink'
+  ? require('./lib/corelink-transport')
+  : require('./lib/relay-transport');
+```
+
+The scripts never `require('corelink')` directly. Rip-out = delete
+`corelink-transport.js`, delete the ternary.
+
+### Python plugin (`plugins/corelink_demo/main.py`)
+
+Mirrors `plugins/reference_plugin/main.py`. Differences:
+
+- Real `_transform(data: bytes) -> bytes` (e.g., upper-case).
+- `[demo-plugin]` log prefix.
+- Same env contract: `CORELINK_HOST`, `CORELINK_PORT`,
+  `CORELINK_USERNAME`, `CORELINK_PASSWORD`, `IN_<TYPE>_WORKSPACE/STREAM_ID/PROTOCOL`,
+  `OUT_<TYPE>_WORKSPACE/STREAM_ID/PROTOCOL`.
+
+All Corelink calls stay in `main.py` (no separate transport module — the
+file is small, the rip-out is "delete the directory"). FastAPI `/health`
+is kept for the executor's liveness check.
+
+### Backend `corelink_admin.py`
+
+```python
+@dataclass
+class CorelinkProvisionResult:
+    workspace: str
+    host: str
+    port: int
+    username: str
+    password: str
+
+class CorelinkAdminError(Exception): ...
+
+async def provision_deployment(deploy_id: str) -> CorelinkProvisionResult:
+    """POST /api/provision on corelink-server with X-Provision-Token. Idempotent.
+    Creates the workspace `workflow_<deploy_id>` if it doesn't already exist."""
+
+async def unprovision_deployment(deploy_id: str) -> None:
+    """DELETE /api/provision/<deploy_id>. Treats 404 as success."""
+```
+
+Reads `CORELINK_HOST`, `CORELINK_PORT`, `CORELINK_PROVISION_TOKEN` from
+env. Uses `httpx.AsyncClient` with TLS verification disabled (Corelink
+server uses a self-signed cert in dev). Timeout 5 s.
+
+### Corelink-server provisioning routes
+
+Added to the existing `httpsControlServer` callback at
+`corelink.js:4562`. No new dependency.
+
+```
+POST /api/provision
+  Headers: X-Provision-Token: <shared secret>
+  Body:    {"deploy_id": "a1b2c3d4"}
+  Response 200: {"workspace": "workflow_a1b2c3d4",
+                 "host": "<server-host>", "port": 20012,
+                 "username": "testuser", "password": "testpassword"}
+  Response 401: missing/wrong token
+  Idempotent: second call with same deploy_id returns the same blob.
+
+DELETE /api/provision/<deploy_id>
+  Headers: X-Provision-Token: <shared secret>
+  Response 200: workspace removed
+  Response 404: workspace already gone (treated as success by the orchestrator)
+```
+
+The route handler internally calls the existing `addWorkspace` /
+`rmWorkspace` admin functions. Stream IDs are not pre-registered — they
+come into existence when senders connect and call `createSender`; the
+orchestrator-generated `stream_id` strings in `StreamCredential` are
+used as filter hints by receivers (`create_receiver(stream_ids=[...])`).
+
+## Data flow & API contracts
+
+### Deploy
+
+`POST /deploy/execute/v2` (request unchanged):
+
+```json
+{
+  "nodes": [
+    {"id": "src", "type": "sender", "out_streams": ["json"]},
+    {"id": "plg", "type": "plugin", "runtime": "corelink_demo:latest",
+     "in_streams": ["json"], "out_streams": ["json"]},
+    {"id": "rcv", "type": "receiver", "in_streams": ["json"]}
+  ],
+  "edges": [
+    {"source": "src", "target": "plg", "data": "json"},
+    {"source": "plg", "target": "rcv", "data": "json"}
+  ]
+}
+```
+
+Backend sequence:
+
+1. `deploy_id = uuid4().hex[:8]`.
+2. `provisioning = await corelink_admin.provision_deployment(deploy_id)`.
+3. `plan = deploy(workflow, deploy_id=deploy_id, workspace=provisioning.workspace, inject_env=True)` — `generate_pub_sub_cred` uses the deploy-scoped workspace; `build_env_vars` injects `CORELINK_HOST/PORT/USERNAME/PASSWORD` into plugin nodes' env_plan from `provisioning`.
+4. Executor starts the plugin container with that env_plan.
+5. `deployments[deploy_id] = {plan, execution, workflow, provisioning}`.
+
+Response:
+
+```json
+{"message": "Deploy executed", "deploy_id": "a1b2c3d4",
+ "workspace": "workflow_a1b2c3d4", "plan": {...}, "execution": [...]}
+```
+
+### Credentials
+
+`GET /deployments/a1b2c3d4/credentials?role=sender` — response gains a
+`corelink` block sourced from the provisioning blob:
+
+```json
+{
+  "deploy_id": "a1b2c3d4", "role": "sender", "node_id": "src",
+  "corelink": {"host": "localhost", "port": 20012,
+               "username": "testuser", "password": "testpassword"},
+  "credentials": {
+    "json": {"workspace": "workflow_a1b2c3d4", "protocol": "pubsub",
+             "stream_id": "src_plg_json_stream",
+             "data_type": "json", "metadata": {}}
+  }
+}
+```
+
+### Sender / receiver connect (corelink mode)
+
+1. Fetch credentials.
+2. `transport.connect({host, deployId, role, credentials})` →
+   internally: `corelink.connect(corelink.username, corelink.password, corelink.host, corelink.port)`,
+   then `corelink.createSender(...)` or sets up `corelink.subscribe(...)`.
+3. REPL loop on sender; subscribe callback on receiver.
+
+### Cleanup
+
+`DELETE /deployments/a1b2c3d4`:
+
+1. Stop plugin container via executor.
+2. `await corelink_admin.unprovision_deployment(deploy_id)`.
+3. Remove `deployments[deploy_id]`.
+4. Return 200 with optional `warnings` array if any step soft-failed.
+
+### Env var summary
+
+| Var | Set by | Read by |
+|---|---|---|
+| `CORELINK_HOST`, `CORELINK_PORT` | `backend/run.sh` | `corelink_admin.py`, `corelink_health.py` |
+| `CORELINK_PROVISION_TOKEN` | `backend/run.sh` (matches token on corelink-server) | `corelink_admin.py` |
+| `CORELINK_USERNAME`, `CORELINK_PASSWORD` (defaults `testuser`/`testpassword`) | provisioning response | injected into plugin container's env_plan |
+| `IN_<TYPE>_WORKSPACE/STREAM_ID/PROTOCOL` | `build_env_vars` | plugin container |
+| `OUT_<TYPE>_WORKSPACE/STREAM_ID/PROTOCOL` | `build_env_vars` | plugin container |
+
+## Error handling
+
+| Failure | Detected by | Behavior | User sees |
+|---|---|---|---|
+| Corelink unreachable at provision time | `corelink_admin.provision_deployment` | `/deploy/execute/v2` returns 503 with `{detail: "corelink unreachable: <reason>"}`. Nothing launched. | HTTP 503. |
+| Provision token rejected (401/403) | `corelink_admin.provision_deployment` | 502 with `{detail: "corelink rejected provision token"}`. | HTTP 502. |
+| Workspace already exists on Corelink | `POST /api/provision` route | Idempotent — returns same blob. | Transparent. |
+| Plugin container fails to connect to Corelink | Plugin's `_corelink_loop` raises → container exits | Executor reports `status: "exited"` for that node. Workspace not auto-cleaned. | Plugin shows `exited` in deploy response. |
+| Sender/receiver can't reach orchestrator | `requests.get` / `fetch` fails | Print `Error fetching credentials: <code>`, exit 1. | CLI exits with message. |
+| Sender/receiver can't connect to Corelink | `transport.connect` rejects | Print `Corelink connect failed: <error>`, exit 1. Suggest `--mode relay`. | CLI exits with hint. |
+| Receiver started before sender | Normal Corelink flow | Receiver prints `Waiting for sender stream…`. No error. | Just waits; works on connect. |
+| Mode mismatch (one corelink, one relay) | Not detectable from one side | Receiver hears nothing. Each script prints `Mode: corelink`/`Mode: relay` banner at startup. | Visible mode banner. |
+| Plugin `_transform` throws | `try/except` in `_on_data` | Log `[demo-plugin] transform error: <e>`, drop message, keep running. | Container logs. |
+| Cleanup partial failure | Each step independently | Stop + unprovision called separately. 404 from unprovision treated as success. Errors logged; state cleaned anyway; response includes `warnings`. | 200 + warnings array. |
+
+Deliberately not handled (acceptable for a demo):
+
+- Backend crash mid-deploy → orphaned workspace on Corelink. Document
+  manual cleanup; rare in practice.
+- Plugin restart resilience.
+- Auth token rotation, replay, rate limits.
+- Concurrent deploy races.
+
+## Testing
+
+### Automated
+
+**Backend (Python, pytest)**
+
+| Test | Coverage |
+|---|---|
+| `tests/test_corelink_admin.py` (new) | `provision_deployment` happy path, timeout → `CorelinkAdminError`, bad token raises specific error, idempotency, `unprovision_deployment` 404 treated as success. Mock HTTP via `respx` or `monkeypatch`. |
+| `tests/test_deployment_planner.py` (extend) | `deploy(deploy_id, workspace)` puts the workspace in every `creds_by_node[*].in_creds/out_creds`; plugin nodes' `env_plan` contains `IN_*_WORKSPACE`, `OUT_*_WORKSPACE`, and `CORELINK_*`; sender/receiver nodes do **not** get `CORELINK_*`. |
+| `tests/test_main.py` (new or extended) | `POST /deploy/execute/v2` happy path with mocked `corelink_admin`; provision failure → 503; `DELETE /deployments/{id}` calls `unprovision_deployment` and tolerates 404. FastAPI `TestClient`. |
+
+**Corelink-server (Node)**
+
+Add to `tests/tests.js`:
+- `POST /api/provision` with valid token returns expected blob.
+- Idempotent on repeat with same `deploy_id`.
+- Missing/wrong `X-Provision-Token` returns 401.
+- `DELETE /api/provision/<id>` succeeds; 404 on second call.
+
+**Node scripts**
+
+- `scripts/lib/relay-transport.js` — unit-tested against in-process
+  mock fetch + EventSource. Long-term path; worth testing.
+- `scripts/lib/corelink-transport.js` — **not unit-tested**; covered by
+  manual demo run. Mocking Corelink is more risk than reward for a
+  throwaway path.
+- Interface conformance test: both transport modules export the same
+  function names with matching arities.
+
+**Plugin**
+
+- `tests/test_transform.py` — pure-function test of `_transform`.
+- `tests/test_env_parsing.py` — `_parse_stream_env("IN_")` against a
+  fabricated env dict.
+
+### Manual demo runbook (also serves as the demo-day script)
+
+1. `cd corelink-server && npm start` — server up on :20012.
+2. `cd backend && ./run.sh` — orchestrator on :8000. Verify
+   `GET /health/corelink` returns `healthy`.
+3. `curl -X POST localhost:8000/deploy/execute/v2 -d @demo-workflow.json`
+   → returns `deploy_id`. Note the returned `workspace`.
+4. (Optional) Verify workspace exists on Corelink.
+5. Terminal A: `node scripts/sender.js <deploy_id>`. Terminal B:
+   `node scripts/receiver.js <deploy_id>`. Both print
+   `Mode: corelink` banner.
+6. Type "hello" in sender → receiver prints `[received] HELLO` (or
+   whichever transform the new plugin implements).
+7. `curl -X DELETE localhost:8000/deployments/<deploy_id>`. Workspace
+   removed on Corelink.
+8. Repeat with `--mode relay` on both scripts; same flow without
+   Corelink.
+
+### Out of scope
+
+- Live end-to-end Corelink in CI (no Corelink server in CI).
+- Concurrent deploys / load.
+- Plugin restart resilience.
+
+## Open questions
+
+None at design time. All design choices have been confirmed in
+brainstorming. The implementation plan will resolve concrete details
+(exact transform, exact protocol names, npm-package-vs-vendored copy of
+`corelink.lib.js`, port bindings).

--- a/frontend/app/api/deploy/route.ts
+++ b/frontend/app/api/deploy/route.ts
@@ -13,12 +13,44 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const injectEnv = request.nextUrl.searchParams.get('inject_env') === 'true';
+  // executor=local launches plugin nodes via the executor (which injects env
+  // vars itself via `docker run -e`). Keep inject_env=false to avoid the
+  // legacy inject_vars_to_image side-effect that spawns a redundant
+  // `docker compose up` container ("t-app-1") and conflicts with the
+  // executor's own start. Either flag is overridable per-request via
+  // query string.
+  const executor = (request.nextUrl.searchParams.get('executor') ?? 'local').toLowerCase();
+  const injectEnv = (request.nextUrl.searchParams.get('inject_env') ?? 'false').toLowerCase();
+  const backendQuery = `executor=${encodeURIComponent(executor)}&inject_env=${encodeURIComponent(injectEnv)}`;
+
+  // Best-effort: DELETE any deployments still active in the orchestrator
+  // before creating a new one. Without this, repeated canvas-deploy clicks
+  // leave orphan plugin containers running (and orphan corelink workspaces
+  // bloating the corelink-server's stream-relay state).
+  try {
+    const listRes = await fetch(`${BACKEND_URL}/deployments`);
+    if (listRes.ok) {
+      const active: Record<string, unknown> = await listRes.json();
+      const deployIds = Object.keys(active);
+      if (deployIds.length > 0) {
+        console.log('[deploy] cleaning up', deployIds.length, 'previous deployment(s) before launching new one');
+        await Promise.all(
+          deployIds.map((id) =>
+            fetch(`${BACKEND_URL}/deployments/${id}`, { method: 'DELETE' })
+              .then(() => undefined)
+              .catch((e) => console.warn('[deploy] failed to DELETE deployment:', id, e)),
+          ),
+        );
+      }
+    }
+  } catch (e) {
+    console.warn('[deploy] previous-deployment cleanup skipped:', e);
+  }
 
   let backendRes: Response;
   try {
     backendRes = await fetch(
-      `${BACKEND_URL}/deploy?inject_env=${injectEnv}`,
+      `${BACKEND_URL}/deploy/execute/v2?${backendQuery}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/lib/nodeTemplates.ts
+++ b/frontend/lib/nodeTemplates.ts
@@ -149,7 +149,7 @@ export const nodeTemplates: NodeTemplate[] = [
       name: 'Caesar Cipher',
       description: 'Shifts letters in the alphabet by a fixed number for encryption/decryption',
       nodeType: 'plugin' as const,
-      runtime: 'ghcr.io/exp-orchestrator/caesar-cipher:latest',
+      runtime: 'caesar_cipher:latest',
       sources: ['encrypted_text', 'cipher_key'],
       access_types: {
         canSend: true,

--- a/plugins/caesar_cipher/Dockerfile
+++ b/plugins/caesar_cipher/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+
+EXPOSE 8080
+
+RUN useradd --no-create-home --shell /bin/false appuser
+USER appuser
+
+CMD ["python", "main.py"]

--- a/plugins/caesar_cipher/main.py
+++ b/plugins/caesar_cipher/main.py
@@ -1,0 +1,166 @@
+"""
+caesar_cipher plugin.
+
+Subscribes to all IN_* streams, applies a Caesar cipher (shift configurable
+via the CAESAR_SHIFT env var, default 10) to each message, publishes to all
+OUT_* streams. Same lifecycle/wiring as plugins/corelink_demo/main.py.
+
+This plugin lives behind the same modular boundary: deleting
+plugins/caesar_cipher/ removes it without affecting the orchestrator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+
+import corelink
+import uvicorn
+from fastapi import FastAPI
+
+_out_senders: dict[str, int] = {}
+_in_receivers: dict[str, int] = {}
+_connected: bool = False
+_SHIFT: int = int(os.environ.get("CAESAR_SHIFT", "10"))
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.environ.get(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.environ.get(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+def _shift_char(c: str, shift: int) -> str:
+    if "a" <= c <= "z":
+        return chr((ord(c) - ord("a") + shift) % 26 + ord("a"))
+    if "A" <= c <= "Z":
+        return chr((ord(c) - ord("A") + shift) % 26 + ord("A"))
+    return c
+
+
+def _transform(data: bytes) -> bytes:
+    """Apply Caesar cipher with shift=_SHIFT to UTF-8 text. Non-UTF-8 passes through."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data
+    return "".join(_shift_char(ch, _SHIFT) for ch in text).encode("utf-8")
+
+
+async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
+    try:
+        result = _transform(data)
+    except Exception as e:
+        print(f"[caesar] transform error on stream_id={stream_id}: {e}")
+        return
+    text = result.decode("utf-8", errors="replace")
+    for sid in _out_senders.values():
+        await corelink.send(sid, text)
+
+
+async def _on_stream_update(message: dict, key: str) -> None:
+    sid = message.get("streamID")
+    if sid is None:
+        return
+    msg_type = (message.get("type") or "").lower()
+    receiver_id = _in_receivers.get(msg_type)
+    targets = [receiver_id] if receiver_id is not None else list(_in_receivers.values())
+    for rid in targets:
+        try:
+            await corelink.subscribe_to_stream(rid, sid)
+            print(f"[caesar] subscribed receiver {rid} to stream {sid} (type={msg_type})")
+        except Exception as e:
+            print(f"[caesar] subscribe error r={rid} s={sid}: {e}")
+
+
+async def _corelink_loop() -> None:
+    host = os.environ.get("CORELINK_HOST", "")
+    port = int(os.environ.get("CORELINK_PORT", "20012"))
+    username = os.environ.get("CORELINK_USERNAME", "")
+    password = os.environ.get("CORELINK_PASSWORD", "")
+
+    if not (host and username and password):
+        print("[caesar] CORELINK_HOST/USERNAME/PASSWORD not set — idle")
+        return
+
+    await corelink.connect(username, password, host, port)
+    global _connected
+    _connected = True
+    print(f"[caesar] Connected to Corelink at {host}:{port} (shift={_SHIFT})")
+
+    await corelink.set_data_callback(_on_data)
+    await corelink.set_server_callback(_on_stream_update, "update")
+
+    in_streams = _parse_stream_env("IN_")
+    for stream_type, cfg in in_streams.items():
+        receiver_id = await corelink.create_receiver(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+            stream_ids=[],
+            alert=True,
+        )
+        _in_receivers[stream_type.lower()] = receiver_id
+        print(f"[caesar] Receiver ready: {stream_type} @ {cfg['workspace']} (rid={receiver_id})")
+
+    out_streams = _parse_stream_env("OUT_")
+    for stream_type, cfg in out_streams.items():
+        sid = await corelink.create_sender(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+        )
+        _out_senders[stream_type] = sid
+        print(f"[caesar] Sender ready: {stream_type} @ {cfg['workspace']} (sid={sid})")
+
+    await asyncio.sleep(float("inf"))
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    print(f"[caesar] NODE_ID={os.environ.get('NODE_ID', '')} shift={_SHIFT}")
+    task = asyncio.create_task(_corelink_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+@app.get("/health")
+def health():
+    if not _connected:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=503,
+            content={"ok": False, "reason": "corelink_disconnected"},
+        )
+    return {"ok": True}
+
+
+@app.get("/run")
+def run_status():
+    return {
+        "node_id": os.environ.get("NODE_ID", ""),
+        "shift": _SHIFT,
+        "in_streams": _parse_stream_env("IN_"),
+        "out_streams": _parse_stream_env("OUT_"),
+        "out_sender_ids": _out_senders,
+        "corelink_connected": _connected,
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/plugins/caesar_cipher/pytest.ini
+++ b/plugins/caesar_cipher/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/plugins/caesar_cipher/requirements.txt
+++ b/plugins/caesar_cipher/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink

--- a/plugins/caesar_cipher/tests/test_transform.py
+++ b/plugins/caesar_cipher/tests/test_transform.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_transform_shifts_lowercase_by_default_10():
+    # Default shift is 10, set before import via env-var fallback below.
+    os.environ["CAESAR_SHIFT"] = "10"
+    # Force a fresh module load so the constant picks up the env.
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    from main import _transform
+    assert _transform(b"hello") == b"rovvy"
+
+
+def test_transform_preserves_non_alpha():
+    os.environ["CAESAR_SHIFT"] = "10"
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    from main import _transform
+    assert _transform(b"hello, world! 123") == b"rovvy, gybvn! 123"
+
+
+def test_transform_preserves_case():
+    os.environ["CAESAR_SHIFT"] = "3"
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    from main import _transform
+    assert _transform(b"AbC xyZ") == b"DeF abC"
+
+
+def test_transform_passes_through_non_utf8():
+    os.environ["CAESAR_SHIFT"] = "10"
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    from main import _transform
+    assert _transform(b"\xff\xfe") == b"\xff\xfe"

--- a/plugins/corelink_demo/Dockerfile
+++ b/plugins/corelink_demo/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim
 
+# Stream Python stdout/stderr unbuffered so [demo-plugin] log lines surface in
+# `docker logs` immediately rather than sitting in a buffer until the process
+# exits. Critical for live debugging of the corelink connect / data flow.
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/plugins/corelink_demo/Dockerfile
+++ b/plugins/corelink_demo/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+
+EXPOSE 8080
+
+RUN useradd --no-create-home --shell /bin/false appuser
+USER appuser
+
+CMD ["python", "main.py"]

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -53,8 +53,11 @@ async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
     except Exception as e:
         print(f"[demo-plugin] transform error on stream_id={stream_id}: {e}")
         return
+    # Python corelink.send expects str (it calls .encode() internally).
+    # _transform returns bytes; decode with `replace` so non-UTF-8 still ships.
+    text = result.decode("utf-8", errors="replace")
     for sid in _out_senders.values():
-        await corelink.send(sid, result)
+        await corelink.send(sid, text)
 
 
 async def _on_stream_update(message: dict, key: str) -> None:

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -73,12 +73,14 @@ async def _corelink_loop() -> None:
 
     in_streams = _parse_stream_env("IN_")
     for stream_type, cfg in in_streams.items():
-        stream_ids = [cfg["stream_id"]] if cfg["stream_id"] else []
+        # stream_ids MUST be empty — they filter by NUMERIC server-assigned IDs,
+        # not the orchestrator's logical stream_id string. The alert=True flag
+        # delivers receiver-callbacks for matching senders.
         await corelink.create_receiver(
             workspace=cfg["workspace"],
             protocol="ws",
             data_type=stream_type.lower(),
-            stream_ids=stream_ids,
+            stream_ids=[],
             alert=True,
         )
         print(f"[demo-plugin] Receiver ready: {stream_type} @ {cfg['workspace']}")

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -1,0 +1,128 @@
+"""
+corelink_demo plugin.
+
+Subscribes to all IN_* streams, runs `_transform` on each message, publishes
+to all OUT_* streams. Mirrors plugins/reference_plugin/main.py — keep them
+in sync if reference_plugin's structure changes.
+
+This entire directory is part of the Corelink rip-out: deleting
+plugins/corelink_demo/ removes the plugin without affecting other code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+
+import corelink
+import uvicorn
+from fastapi import FastAPI
+
+_out_senders: dict[str, int] = {}
+
+
+def _parse_stream_env(prefix: str) -> dict[str, dict]:
+    streams: dict[str, dict] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and key.endswith("_WORKSPACE"):
+            stream_type = key[len(prefix): -len("_WORKSPACE")]
+            streams[stream_type] = {
+                "workspace": val,
+                "stream_id": os.environ.get(f"{prefix}{stream_type}_STREAM_ID", ""),
+                "protocol": os.environ.get(f"{prefix}{stream_type}_PROTOCOL", "pubsub"),
+            }
+    return streams
+
+
+def _transform(data: bytes) -> bytes:
+    """Demo transform: uppercase UTF-8 text. Non-UTF-8 passes through."""
+    try:
+        return data.decode("utf-8").upper().encode("utf-8")
+    except UnicodeDecodeError:
+        return data
+
+
+async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
+    try:
+        result = _transform(data)
+    except Exception as e:
+        print(f"[demo-plugin] transform error: {e}")
+        return
+    for sid in _out_senders.values():
+        await corelink.send(sid, result)
+
+
+async def _corelink_loop() -> None:
+    host = os.environ.get("CORELINK_HOST", "")
+    port = int(os.environ.get("CORELINK_PORT", "20012"))
+    username = os.environ.get("CORELINK_USERNAME", "")
+    password = os.environ.get("CORELINK_PASSWORD", "")
+
+    if not (host and username and password):
+        print("[demo-plugin] CORELINK_HOST/USERNAME/PASSWORD not set — idle")
+        return
+
+    await corelink.connect(username, password, host, port)
+    print(f"[demo-plugin] Connected to Corelink at {host}:{port}")
+
+    await corelink.set_data_callback(_on_data)
+
+    in_streams = _parse_stream_env("IN_")
+    for stream_type, cfg in in_streams.items():
+        stream_ids = [cfg["stream_id"]] if cfg["stream_id"] else []
+        await corelink.create_receiver(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+            stream_ids=stream_ids,
+            alert=True,
+        )
+        print(f"[demo-plugin] Receiver ready: {stream_type} @ {cfg['workspace']}")
+
+    out_streams = _parse_stream_env("OUT_")
+    for stream_type, cfg in out_streams.items():
+        sid = await corelink.create_sender(
+            workspace=cfg["workspace"],
+            protocol="ws",
+            data_type=stream_type.lower(),
+        )
+        _out_senders[stream_type] = sid
+        print(f"[demo-plugin] Sender ready: {stream_type} @ {cfg['workspace']} (sid={sid})")
+
+    await asyncio.sleep(float("inf"))
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    print(f"[demo-plugin] NODE_ID={os.environ.get('NODE_ID', '')}")
+    task = asyncio.create_task(_corelink_loop())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/run")
+def run_status():
+    return {
+        "node_id": os.environ.get("NODE_ID", ""),
+        "in_streams": _parse_stream_env("IN_"),
+        "out_streams": _parse_stream_env("OUT_"),
+        "out_sender_ids": _out_senders,
+        "corelink_connected": bool(_out_senders),
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -54,6 +54,23 @@ async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
         await corelink.send(sid, result)
 
 
+async def _on_stream_update(message: dict, key: str) -> None:
+    """Subscribe to new senders that arrive after we created our receiver.
+
+    Corelink fires this callback (key='update') for every alert. Stream-alert
+    messages carry a `streamID` we should subscribe to so the plugin actually
+    receives data from senders that connect later (e.g., the user starting
+    sender.js after the deploy).
+    """
+    sid = message.get("streamID")
+    if sid is None:
+        return
+    try:
+        await corelink.subscribe(stream_ids=[sid])
+    except Exception as e:
+        print(f"[demo-plugin] subscribe error for stream_id={sid}: {e}")
+
+
 async def _corelink_loop() -> None:
     host = os.environ.get("CORELINK_HOST", "")
     port = int(os.environ.get("CORELINK_PORT", "20012"))
@@ -70,6 +87,10 @@ async def _corelink_loop() -> None:
     print(f"[demo-plugin] Connected to Corelink at {host}:{port}")
 
     await corelink.set_data_callback(_on_data)
+    # Subscribe to senders that arrive after the receiver is set up.
+    # The Python corelink client doesn't auto-subscribe via alert=True;
+    # we have to explicitly handle the 'update' callback.
+    await corelink.set_server_callback(_on_stream_update, "update")
 
     in_streams = _parse_stream_env("IN_")
     for stream_type, cfg in in_streams.items():

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -20,6 +20,9 @@ import uvicorn
 from fastapi import FastAPI
 
 _out_senders: dict[str, int] = {}
+# data_type (lowercase) → receiver_id, populated as create_receiver returns.
+# Used to route stream-alert subscriptions to the correct receiver.
+_in_receivers: dict[str, int] = {}
 _connected: bool = False
 
 
@@ -58,17 +61,29 @@ async def _on_stream_update(message: dict, key: str) -> None:
     """Subscribe to new senders that arrive after we created our receiver.
 
     Corelink fires this callback (key='update') for every alert. Stream-alert
-    messages carry a `streamID` we should subscribe to so the plugin actually
-    receives data from senders that connect later (e.g., the user starting
-    sender.js after the deploy).
+    messages carry a `streamID` and a `type` indicating which of our receivers
+    should subscribe. The Python corelink client's API is
+    subscribe_to_stream(receiver_id, stream_id) — we look up the receiver_id
+    by data type (the message's 'type' field, mirroring create_receiver's
+    data_type).
     """
     sid = message.get("streamID")
     if sid is None:
         return
-    try:
-        await corelink.subscribe(stream_ids=[sid])
-    except Exception as e:
-        print(f"[demo-plugin] subscribe error for stream_id={sid}: {e}")
+    msg_type = (message.get("type") or "").lower()
+    receiver_id = _in_receivers.get(msg_type)
+    if receiver_id is None:
+        # Fall back to subscribing on every receiver we have, in case the
+        # type field is missing or differently cased.
+        targets = list(_in_receivers.values())
+    else:
+        targets = [receiver_id]
+    for rid in targets:
+        try:
+            await corelink.subscribe_to_stream(rid, sid)
+            print(f"[demo-plugin] subscribed receiver {rid} to stream {sid} (type={msg_type})")
+        except Exception as e:
+            print(f"[demo-plugin] subscribe error r={rid} s={sid}: {e}")
 
 
 async def _corelink_loop() -> None:
@@ -97,14 +112,15 @@ async def _corelink_loop() -> None:
         # stream_ids MUST be empty — they filter by NUMERIC server-assigned IDs,
         # not the orchestrator's logical stream_id string. The alert=True flag
         # delivers receiver-callbacks for matching senders.
-        await corelink.create_receiver(
+        receiver_id = await corelink.create_receiver(
             workspace=cfg["workspace"],
             protocol="ws",
             data_type=stream_type.lower(),
             stream_ids=[],
             alert=True,
         )
-        print(f"[demo-plugin] Receiver ready: {stream_type} @ {cfg['workspace']}")
+        _in_receivers[stream_type.lower()] = receiver_id
+        print(f"[demo-plugin] Receiver ready: {stream_type} @ {cfg['workspace']} (rid={receiver_id})")
 
     out_streams = _parse_stream_env("OUT_")
     for stream_type, cfg in out_streams.items():

--- a/plugins/corelink_demo/main.py
+++ b/plugins/corelink_demo/main.py
@@ -20,6 +20,7 @@ import uvicorn
 from fastapi import FastAPI
 
 _out_senders: dict[str, int] = {}
+_connected: bool = False
 
 
 def _parse_stream_env(prefix: str) -> dict[str, dict]:
@@ -47,7 +48,7 @@ async def _on_data(data: bytes, stream_id: int, header: dict) -> None:
     try:
         result = _transform(data)
     except Exception as e:
-        print(f"[demo-plugin] transform error: {e}")
+        print(f"[demo-plugin] transform error on stream_id={stream_id}: {e}")
         return
     for sid in _out_senders.values():
         await corelink.send(sid, result)
@@ -64,6 +65,8 @@ async def _corelink_loop() -> None:
         return
 
     await corelink.connect(username, password, host, port)
+    global _connected
+    _connected = True
     print(f"[demo-plugin] Connected to Corelink at {host}:{port}")
 
     await corelink.set_data_callback(_on_data)
@@ -110,6 +113,16 @@ app = FastAPI(lifespan=_lifespan)
 
 @app.get("/health")
 def health():
+    # Returns 503 when Corelink isn't connected so that the orchestrator
+    # (and human operators) can distinguish "container running" from
+    # "container running AND data plane wired up". Liveness-style probes
+    # should use a different endpoint if they want process-only health.
+    if not _connected:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=503,
+            content={"ok": False, "reason": "corelink_disconnected"},
+        )
     return {"ok": True}
 
 
@@ -120,7 +133,7 @@ def run_status():
         "in_streams": _parse_stream_env("IN_"),
         "out_streams": _parse_stream_env("OUT_"),
         "out_sender_ids": _out_senders,
-        "corelink_connected": bool(_out_senders),
+        "corelink_connected": _connected,
     }
 
 

--- a/plugins/corelink_demo/pytest.ini
+++ b/plugins/corelink_demo/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/plugins/corelink_demo/requirements.txt
+++ b/plugins/corelink_demo/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+corelink

--- a/plugins/corelink_demo/tests/test_transform.py
+++ b/plugins/corelink_demo/tests/test_transform.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_transform_uppercases_text():
+    from main import _transform
+    assert _transform(b"hello world") == b"HELLO WORLD"
+
+
+def test_transform_handles_empty():
+    from main import _transform
+    assert _transform(b"") == b""
+
+
+def test_transform_passes_through_non_utf8():
+    from main import _transform
+    # Non-UTF-8 bytes pass through unchanged
+    assert _transform(b"\xff\xfe") == b"\xff\xfe"

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.venv/

--- a/scripts/lib/__tests__/interface.test.js
+++ b/scripts/lib/__tests__/interface.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+test('corelink-transport exports the same shape as relay-transport', () => {
+  const corelink = require('../corelink-transport')
+  const relay = require('../relay-transport')
+  for (const fn of ['connect', 'send', 'subscribe', 'close']) {
+    assert.equal(typeof corelink[fn], 'function', `corelink-transport missing ${fn}`)
+    assert.equal(typeof relay[fn], 'function', `relay-transport missing ${fn}`)
+  }
+})

--- a/scripts/lib/__tests__/relay-transport.test.js
+++ b/scripts/lib/__tests__/relay-transport.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+test('relay-transport exports the expected interface', () => {
+  const t = require('../relay-transport')
+  assert.equal(typeof t.connect, 'function')
+  assert.equal(typeof t.send, 'function')
+  assert.equal(typeof t.subscribe, 'function')
+  assert.equal(typeof t.close, 'function')
+})
+
+test('relay-transport.send POSTs to backend with the message', async () => {
+  const calls = []
+  const fakeFetch = async (url, opts) => {
+    calls.push({ url, opts })
+    return { ok: true, status: 200, json: async () => ({ status: 'ok', listeners: 1 }) }
+  }
+  const t = require('../relay-transport')
+  const handle = await t.connect({
+    host: 'http://localhost:8000',
+    deployId: 'abc',
+    role: 'sender',
+    credentials: {},
+    _fetch: fakeFetch,
+  })
+  await t.send(handle, 'hello')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'http://localhost:8000/deployments/abc/messages')
+  assert.deepEqual(JSON.parse(calls[0].opts.body), { data: 'hello' })
+})

--- a/scripts/lib/corelink-transport.js
+++ b/scripts/lib/corelink-transport.js
@@ -1,0 +1,67 @@
+/**
+ * Corelink transport — wraps the vendored corelink.lib.js client.
+ *
+ * This file is the ONLY place in scripts/ that imports the corelink client.
+ * Deleting this file (and removing the require() ternary in sender.js/receiver.js,
+ * and the lib/vendor/ directory) is the rip-out path.
+ */
+
+const corelink = require('./vendor/corelink.lib.js')
+
+async function connect({ host, deployId, role, credentials, corelinkBlock }) {
+  if (!corelinkBlock) {
+    throw new Error('corelink block missing from credentials response')
+  }
+  await corelink.connect(
+    { username: corelinkBlock.username, password: corelinkBlock.password },
+    { ControlIP: corelinkBlock.host, ControlPort: corelinkBlock.port },
+  )
+
+  const streamTypes = Object.keys(credentials || {})
+  if (streamTypes.length === 0) {
+    throw new Error(`no ${role} credentials found in deployment ${deployId}`)
+  }
+  const streamType = streamTypes[0]
+  const cred = credentials[streamType]
+
+  if (role === 'sender') {
+    const sendId = await corelink.createSender({
+      workspace: cred.workspace,
+      protocol: 'ws',
+      type: cred.data_type,
+    })
+    return { role, sendId, cred, streamType }
+  }
+  // receiver
+  return { role, cred, streamType }
+}
+
+async function send(handle, message) {
+  if (handle.role !== 'sender') throw new Error('send() called on non-sender handle')
+  await corelink.send(handle.sendId, Buffer.from(message, 'utf-8'))
+}
+
+async function subscribe(handle, onMessage) {
+  if (handle.role !== 'receiver') throw new Error('subscribe() called on non-receiver handle')
+  corelink.on('receiver', async (data) => {
+    const streamIDs = [data.streamID]
+    await corelink.subscribe({ streamIDs })
+  })
+  corelink.on('data', (streamID, data) => {
+    onMessage(data.toString('utf-8'))
+  })
+  await corelink.createReceiver({
+    workspace: handle.cred.workspace,
+    streamIDs: handle.cred.stream_id ? [handle.cred.stream_id] : [],
+    type: handle.cred.data_type,
+    protocol: 'ws',
+    alert: true,
+  })
+  return async () => { await corelink.exit() }
+}
+
+async function close(handle) {
+  await corelink.exit()
+}
+
+module.exports = { connect, send, subscribe, close }

--- a/scripts/lib/corelink-transport.js
+++ b/scripts/lib/corelink-transport.js
@@ -47,23 +47,30 @@ async function send(handle, message) {
 
 async function subscribe(handle, onMessage) {
   if (handle.role !== 'receiver') throw new Error('subscribe() called on non-receiver handle')
+  // on('receiver') fires for senders that arrive AFTER our createReceiver call.
   corelink.on('receiver', async (data) => {
-    const streamIDs = [data.streamID]
-    await corelink.subscribe({ streamIDs })
+    await corelink.subscribe({ streamIDs: [data.streamID] })
   })
   corelink.on('data', (streamID, data) => {
     onMessage(data.toString('utf-8'))
   })
-  // streamIDs MUST be empty here — they're filter hints by NUMERIC server-assigned
-  // ID, not by the orchestrator's logical stream_id string. The on('receiver')
-  // handler above subscribes to whichever sender shows up via the alert flow.
-  await corelink.createReceiver({
+  // streamIDs filter is by NUMERIC server-assigned ID, not the orchestrator's
+  // logical stream_id string — pass [] and rely on workspace+type filtering.
+  // createReceiver resolves with an array of pre-existing matching streams
+  // (each {streamID, ...}); we subscribe to those explicitly so plugins or
+  // other senders that started before the receiver still get delivered.
+  const streamList = await corelink.createReceiver({
     workspace: handle.cred.workspace,
     streamIDs: [],
     type: handle.cred.data_type,
     protocol: 'ws',
     alert: true,
   })
+  for (const item of streamList || []) {
+    if (item && item.streamID != null) {
+      await corelink.subscribe({ streamIDs: [item.streamID] })
+    }
+  }
   return async () => { await corelink.exit() }
 }
 

--- a/scripts/lib/corelink-transport.js
+++ b/scripts/lib/corelink-transport.js
@@ -6,6 +6,10 @@
  * and the lib/vendor/ directory) is the rip-out path.
  */
 
+// corelink-server uses a self-signed TLS cert in dev. Mirrors the Python
+// corelink_admin client, which uses verify=False on httpx.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
 const corelink = require('./vendor/corelink.lib.js')
 
 async function connect({ host, deployId, role, credentials, corelinkBlock }) {
@@ -50,9 +54,12 @@ async function subscribe(handle, onMessage) {
   corelink.on('data', (streamID, data) => {
     onMessage(data.toString('utf-8'))
   })
+  // streamIDs MUST be empty here — they're filter hints by NUMERIC server-assigned
+  // ID, not by the orchestrator's logical stream_id string. The on('receiver')
+  // handler above subscribes to whichever sender shows up via the alert flow.
   await corelink.createReceiver({
     workspace: handle.cred.workspace,
-    streamIDs: handle.cred.stream_id ? [handle.cred.stream_id] : [],
+    streamIDs: [],
     type: handle.cred.data_type,
     protocol: 'ws',
     alert: true,

--- a/scripts/lib/relay-transport.js
+++ b/scripts/lib/relay-transport.js
@@ -1,0 +1,63 @@
+/**
+ * Relay transport — sends/subscribes via the orchestrator backend's HTTP/SSE
+ * endpoints. No Corelink dependency; this is the long-term path that remains
+ * after Corelink is ripped out.
+ */
+
+const httpStream = require('http')
+const httpsStream = require('https')
+
+async function connect({ host, deployId, role, credentials, _fetch = globalThis.fetch }) {
+  return { host, deployId, role, _fetch }
+}
+
+async function send(handle, message) {
+  const url = `${handle.host}/deployments/${handle.deployId}/messages`
+  const resp = await handle._fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: message }),
+  })
+  if (!resp.ok) {
+    throw new Error(`relay POST failed: ${resp.status}`)
+  }
+  return resp.json()
+}
+
+async function subscribe(handle, onMessage) {
+  // Stream Server-Sent Events from /deployments/{id}/messages.
+  const url = new URL(`${handle.host}/deployments/${handle.deployId}/messages`)
+  const isHttps = url.protocol === 'https:'
+  const lib = isHttps ? httpsStream : httpStream
+  return new Promise((resolve, reject) => {
+    const req = lib.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`relay subscribe failed: ${res.statusCode}`))
+        return
+      }
+      let buffer = ''
+      res.on('data', (chunk) => {
+        buffer += chunk.toString('utf-8')
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            try {
+              const payload = JSON.parse(line.slice(6))
+              if (payload.message != null) onMessage(payload.message)
+            } catch { /* ignore malformed line */ }
+          }
+        }
+      })
+      res.on('end', () => resolve(() => req.destroy()))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    // Resolve immediately with an unsubscribe — caller blocks elsewhere
+    setImmediate(() => resolve(() => req.destroy()))
+  })
+}
+
+async function close(handle) { /* nothing to close on relay side */ }
+
+module.exports = { connect, send, subscribe, close }

--- a/scripts/lib/vendor/corelink.lib.js
+++ b/scripts/lib/vendor/corelink.lib.js
@@ -1,0 +1,1501 @@
+
+/* eslint-disable no-async-promise-executor */
+/* eslint-disable no-restricted-syntax */
+
+
+/**
+ * @file NodeJS client library for Corelink
+ * @author Robert Pahle, Abhishek Khanna
+ * @version V5.1.2
+ */
+
+
+// V5.1.2 changed versioning number
+// V5.1.0.2 fixed server
+// V5.1.0.1 fixed race condition
+// V5.1.0.0 Generic function Implementation
+// V5.0.0.0 TCP can also be used as Data protocol
+// V4.0.0.0 Web socket can also be used as Data protocol
+// V3.1.0.0 switch to websockets as default control connection
+// V3.0.0.0 new data protocol
+// V2.4.0.0 added initial browser checks
+// V2.3.0.0 added initial autoReconnect option
+// V2.2.0.0 changed receiver,sender and disconnect calls to use JSON options
+// V2.1.0.0 added subscriber and dropped callbacks
+// V2.0.0.0 changed to json syntax for createSender, createReceiver and
+
+// set debug to true for additional error reporting
+let debug = false
+
+// test for nodejs
+if (typeof module !== 'undefined' && this.module !== module) {
+  if (process.versions.node.split('.')[0] < 12) {
+    console.error(`The current node version ${process.versions.node} does not meet the minimmum requirements of 12.0.0`)
+    process.exit()
+  }
+} else { console.log('This library is designed to run in NodeJS.') }
+
+// const { PromiseSocket } = require('promise-socket')
+const WebSocket = require('websocket').w3cwebsocket
+const dns = require('dns')
+const fs = require('fs')
+const dgram = require('dgram')
+const net = require('net')
+// const { client } = require('websocket')
+
+// const headerSize = Buffer.alloc(8)
+
+let attempts = 0
+let connected = false
+
+
+const receiverStream = {}
+const senderStreams = []
+const allowedStreams = []
+const cert = {}
+let token = null
+
+let sourceIP = null
+let sourcePort = null
+
+let udpRegistered = false
+let udp = null
+let udpServerAddress = null
+let connCredentials = null
+let connConfig = null
+
+
+let dataCb = null
+let receiverCb = null
+let senderCb = null
+let staleCb = null
+let droppedCb = null
+let closeCb = null
+
+
+/**
+* Helper function to create random exponential delay to reconnect
+* @param {string} data JSON string to decode.
+* @returns {object} Javascript object with the parsed data
+* @private
+* @module parseJson
+*/
+
+function generateInterval(k) {
+  let maxInterval = ((2 ** k) - 1) * 1000
+  if (maxInterval > 30 * 1000) {
+    maxInterval = 30 * 1000
+  }
+  return Math.random() * maxInterval
+}
+
+
+/**
+* Helper function to parse JSON
+* @param {string} data JSON string to decode.
+* @returns {object} Javascript object with the parsed data
+* @private
+* @module parseJson
+*/
+
+function parseJson(data) {
+  return (new Promise((resolve, reject) => {
+    try {
+      const parsedData = JSON.parse(`[${data.toString().replace(/}{/g, '},{')}]`)
+      resolve(parsedData)
+    } catch (e) {
+      reject(new Error(`Received message not a proper JSON: ${data.toString()}`))
+    }
+  }))
+}
+
+
+// all control stream functions
+
+const control = {}
+control.data = []
+control.ID = 0
+
+control.connect = async (IP, port, caPath = null) => (new Promise(async (resolve, reject) => {
+  const URL = `wss://${IP}:${port}/`
+  if (debug) console.log(`Trying to connect to: ${URL}`)
+  if (caPath != null) {
+    cert.ca = fs.readFileSync(caPath)
+  } else if ((IP === 'localhost' || IP === '127.0.0.1' || IP === '::1') && (typeof connConfig.cert !== 'undefined')) {
+    cert.ca = fs.readFileSync(connConfig.cert)
+  }
+  try {
+    control.client = new WebSocket(URL, null, null, null, cert)
+  } catch (e) {
+    console.error('Not able to connect the websocket.', e)
+    reject(e)
+  }
+
+  control.client.onopen = () => {
+    resolve()
+  }
+
+  control.client.onerror = (e) => {
+    console.log('Connection Error:', e)
+    reject()
+  }
+
+  control.request = async (data) => {
+    if (debug) console.log('request', data)
+    return (new Promise(async (requestResolve, requestReject) => {
+      const wdata = data
+      wdata.ID = control.ID
+      control.ID += 1
+      let retries = 5
+      control.client.onmessage = (async (content) => {
+        const parsed = await parseJson(content.data).catch((e) => requestReject(e))
+        if (debug) console.log('parsed all', parsed)
+        for (let i = 0; i < parsed.length; i += 1) {
+          if ('function' in parsed[i]) {
+            if (debug) console.log('call 2nd func')
+            control.client.onmessage1(parsed)
+          }
+          retries -= 1
+          if ('ID' in parsed[i] && parsed[i].ID === wdata.ID) {
+            delete parsed[i].ID
+            if (debug) console.log('parsed', parsed[i])
+            if ('statusCode' in parsed[i]) {
+              if (parsed[i].statusCode === 0) {
+                requestResolve(parsed[i])
+                break
+              } if ('message' in parsed[i]) reject(new Error(`${parsed[i].message} (${parsed[i].statusCode})`))
+              else reject(new Error(`Error (${parsed[i].statusCode}) with out specific message returned.`))
+            } reject(new Error('Status code or function not found in answer.'))
+          }
+          if (retries === 0) requestReject(new Error('Server did not responded with an answer.'))
+        }
+      })
+      control.client.send(JSON.stringify(wdata))
+      if (debug) console.log('request sent:', JSON.stringify(wdata))
+    }))
+  }
+
+  control.client.onmessage1 = (async (data) => {
+    if (debug) console.log('onmessage', data)
+    for (let i = 0; i < data.length; i += 1) {
+      const parsedData = data[i]
+      if ('function' in parsedData) {
+        if (debug) console.log('function')
+        switch (parsedData.function) {
+          case 'update':
+            if (receiverCb != null) {
+              delete parsedData.function
+              receiverCb(parsedData)
+            } else console.log('No receiver update callback provided.')
+            break
+          case 'subscriber':
+            if (senderCb != null) {
+              delete parsedData.function
+              senderCb(parsedData)
+            } else console.log('No sender update callback provided.')
+            break
+          case 'stale':
+            if (staleCb != null) {
+              delete parsedData.function
+              staleCb(parsedData)
+            } else console.log('No stale update callback provided.')
+            break
+          case 'dropped':
+            if (droppedCb != null) {
+              delete parsedData.function
+              droppedCb(parsedData)
+            } else console.log('No dropped update callback provided.')
+            break
+          default:
+            console.log('Unknown callback. Maybe this library is outdated?')
+        }
+      }
+    }
+  })
+
+  /**
+  *Call the on function with either data or close function.
+  * @param {string} data The module is defined to parse JSON data. The client checks for the
+                          'function' in data. The event 'update' or 'status' will be triggered
+                          and accordingly 'receiver_cb' or 'stale_cb' will be checked for
+                          null values.
+  * @param {string} close The callback function close_cb is checked for null values and close_cb()
+                          is called
+  * @module on
+  */
+
+  // make connect attemps and manage exponential backoff in connection attempts
+  function reconnect() {
+    control.connect(connCredentials, connConfig).catch((err) => {
+      console.log('Connection failed.', err)
+    })
+  }
+
+
+  control.client.onclose = (e) => {
+    if (debug) console.log('onclose:', e)
+    console.log('reconnect: ', connConfig.autoReconnect)
+    if (connConfig.autoReconnect) {
+      if (closeCb != null) closeCb()
+      else console.log('No close connection callback provided.')
+      console.log(`Control connection lost: Retrying websocket (${attempts})`)
+      const time = generateInterval(attempts)
+      console.log(`Waiting ${time}ms to reconnect.`)
+      setTimeout(() => {
+        attempts += 1
+        reconnect(attempts)
+      }, time)
+    } else
+    if (closeCb != null) closeCb()
+    else {
+      console.log('No close connection callback provided.')
+    }
+  }
+}))
+
+// TCP data Stream Functions
+
+async function receiverSetupTCP(streamID, port) {
+  return (new Promise(((resolve, reject) => {
+    const host = connConfig.ControlIP
+    const buffer = []
+    const headerSize = Buffer.alloc(8)
+
+    receiverStream.client = new net.Socket()
+    receiverStream.client.connect(port, host, () => {
+      if (debug) console.log('Reciver connected to server')
+      headerSize.writeUInt16LE(0, 0)
+      headerSize.writeUInt16LE(0, 2)
+      headerSize.writeUInt32LE(streamID, 4)
+      // adding header
+      if (debug) console.log('bufferlength to send:', headerSize.byteLength)
+      receiverStream.client.write(headerSize)
+
+      resolve(true)
+    })
+
+    if (debug) console.log('init packet TCP: ', headerSize.toString(), port, connConfig.ControlIP)
+
+    receiverStream.client.on('error', (err) => {
+      reject(err)
+    })
+
+    function helper(message) {
+      const headSize = message.readUInt16LE(0)
+      const dataSize = message.readUInt16LE(2)
+      const sourceID = message.readUInt32LE(4)
+      let header = message.toString('ascii', 8, headSize + 8)
+      const dataR = Buffer.allocUnsafe(dataSize)
+      message.copy(dataR, 0, 8 + headSize)
+      if (header.length > 0) {
+        try {
+          header = JSON.parse(header)
+        } catch (e) {
+          console.log(`Received message not a proper JSON: ${message.toString()}`)
+          return
+        }
+      } else header = {}
+      dataCb(sourceID, dataR, header)
+    }
+
+
+    receiverStream.client.on('data', (message) => {
+      if (message.length < 8) {
+        console.log('Packet is too small')
+        return
+      }
+      if (dataCb != null) {
+        if (message.length === 65536) {
+          buffer.push(message)
+        } else if (buffer.length > 0) {
+          buffer.push(message)
+          let calculatedSize = 0
+          let pointer = 0
+          const msg = Buffer.concat(buffer)
+          // for combined packets we need to match the source/federation id and the overall size
+          while (buffer.length > calculatedSize) {
+            calculatedSize += 8
+            calculatedSize += msg.readUInt16LE(pointer)
+            calculatedSize += msg.readUInt16LE(pointer + 2)
+            if (msg.length < calculatedSize) {
+              console.log(`Combined packet has wrong size (${msg.length} vs. ${calculatedSize}).`)
+              return
+            }
+            const data = Buffer.allocUnsafe(calculatedSize - pointer)
+            msg.copy(data, 0, pointer, calculatedSize)
+            helper(data)
+            pointer = calculatedSize
+          }
+
+          if (msg.length !== calculatedSize) {
+            console.log(`Combined packet has still the wrong size (${msg.length} vs. ${calculatedSize}).`)
+          }
+        } else {
+          helper(message)
+        }
+      } else console.log('Data received, but no callback for data available.')
+    })
+  })))
+}
+
+async function senderSetupTCP(streamID = null, port = null) {
+  return (new Promise(((resolve, reject) => {
+    const host = connConfig.ControlIP
+    if (debug) console.log('setting up data TCP', 'streamID', streamID, 'port', port, `Trying to connect to: ${URL}`)
+
+    try {
+      senderStreams[streamID].client = new net.Socket()
+      senderStreams[streamID].client.connect(port, host, () => {
+        if (debug) console.log('sender connected to server')
+        resolve(true)
+      })
+    } catch (e) {
+      console.error('Not able to connect the TCP for Data Stream.', e)
+      if (debug) console.error('sender Streams', senderStreams)
+      reject(e)
+    }
+    senderStreams[streamID].client.on('error', (err) => {
+      reject(err)
+    })
+  })))
+}
+
+// WS data Stream Functions
+
+
+async function receiverSetupWS(streamID = null, port = null) {
+  return (new Promise(((resolve, reject) => {
+    const IP = connConfig.ControlIP
+    const URL = `wss://${IP}:${port}/`
+    const headerSize = Buffer.alloc(8)
+
+    if (debug) console.log('setting up data WS', 'streamID', streamID, 'port', port, `Trying to connect to: ${URL}`)
+    try {
+      receiverStream.client = new WebSocket(URL, null, null, null, cert)
+    } catch (e) {
+      console.error('Not able to connect the websocket for Data Stream.', e)
+      if (debug) console.error('receiverStream', receiverStream)
+      reject(e)
+    }
+
+    receiverStream.client.addEventListener('open', () => {
+      headerSize.writeUInt16LE(0, 0)
+      headerSize.writeUInt16LE(0, 2)
+      headerSize.writeUInt32LE(streamID, 4)
+      // adding header
+      console.log('bufferlength to send:', headerSize.byteLength)
+
+      receiverStream.client.send(headerSize)
+
+      resolve(token)
+    })
+
+    receiverStream.client.addEventListener('error', (err) => {
+      reject(err)
+    })
+
+    receiverStream.client.addEventListener('message', (message) => {
+      if (dataCb != null) {
+        const data = Buffer.from(message.data)
+        const headSize = data.readUInt16LE(0)
+        const dataSize = data.readUInt16LE(2)
+        const sourceID = data.readUInt32LE(4)
+        let header = data.toString('ascii', 8, headSize + 8)
+        const dataR = Buffer.allocUnsafe(dataSize)
+        data.copy(dataR, 0, 8 + headSize)
+        if (header.length > 0) {
+          try {
+            header = JSON.parse(header)
+          } catch (e) {
+            console.log(`Received message not a proper JSON: ${message.toString()}`)
+            return
+          }
+        } else header = {}
+        dataCb(sourceID, dataR, header)
+      } else console.log('Data received, but no callback for data available.')
+    })
+  })))
+}
+
+
+async function senderSetupWS(streamID = null, port = null) {
+  return (new Promise(((resolve, reject) => {
+    const IP = connConfig.ControlIP
+    const URL = `wss://${IP}:${port}/`
+    if (debug) console.log('setting up data WS', 'streamID', streamID, 'port', port, `Trying to connect to: ${URL}`)
+    try {
+      senderStreams[streamID].client = new WebSocket(URL, null, null, null, cert)
+    } catch (e) {
+      console.error('Not able to connect the websocket for Data Stream.', e)
+      if (debug) console.error('sender Streams', senderStreams)
+      reject(e)
+    }
+
+    senderStreams[streamID].client.addEventListener('open', () => {
+      resolve(true)
+    })
+
+    senderStreams[streamID].client.addEventListener('error', (err) => {
+      reject(err)
+    })
+  })))
+}
+
+
+// UDP data stream functions
+
+function receiverSetupUDP(streamID, port) {
+  const headerSize = Buffer.alloc(8)
+  headerSize.writeUInt16LE(0, 0)
+  headerSize.writeUInt16LE(0, 2)
+  headerSize.writeUInt32LE(streamID, 4)
+
+  if (debug) console.log('init packet UDP: ', headerSize.toString(), port, connConfig.ControlIP)
+  udp.send(headerSize, port, connConfig.ControlIP, (err) => {
+    if (debug) console.log('Initializing Receiver UDP...')
+    if (err) console.log('socket error', err)
+  })
+}
+
+async function setupUDP(streamID = null, port = null) {
+  return (new Promise(((resolve, reject) => {
+    if (debug) console.log('setting up UDP', 'streamID', streamID, 'port', port)
+    udp = dgram.createSocket('udp4')
+    udp.bind()
+    udp.on('listening', () => {
+      const address = udp.address()
+      sourcePort = address.port
+      if (debug) console.log(`Bound to UDP port ${sourcePort}.`)
+      udpRegistered = true
+      dns.lookup(connConfig.ControlIP, (err, serverAddress) => {
+        if (debug) console.log(`err: ${err}`)
+        udpServerAddress = serverAddress
+        if (debug) console.log('address:', udpServerAddress)
+      })
+      if ((streamID != null) && (port != null)) {
+        receiverSetupUDP(streamID, port)
+      }
+      resolve(true)
+    })
+    udp.on('error', (err) => {
+      reject(err)
+    })
+    udp.on('message', (message, info) => {
+      if (dataCb != null) {
+        const headSize = message.readUInt16LE(0)
+        const dataSize = message.readUInt16LE(2)
+        const sourceID = message.readUInt32LE(4)
+        let header = message.toString('ascii', 8, headSize + 8)
+        const dataR = Buffer.allocUnsafe(dataSize)
+        message.copy(dataR, 0, 8 + headSize)
+        if (header.length > 0) {
+          try {
+            header = JSON.parse(header)
+          } catch (e) {
+            console.log(`Received message not a proper JSON: ${message.toString()}`)
+            return
+          }
+        } else header = {}
+
+        // if (debug) console.log('streams: ', allowedStreams[0], sourceID, ' IP\'s: ',
+        // connConfig.ControlIP, info.address, ' ports:', receiverStream.port, info.port)
+
+        // if (debug) console.log(`IP address comparison: ${info.address} , ${udpServerAddress}`)
+        if ((info.address === udpServerAddress)
+           && allowedStreams.includes(sourceID)
+           && (receiverStream.port === info.port)) dataCb(sourceID, dataR, header)
+        else console.log(`packet from unauthorized address ${info.address}:${info.port}`)
+      } else console.log('Data received, but no callback for data available.')
+    })
+  })))
+}
+
+/**
+ *The function first checks if the array of streamIDs is not empty as well as
+ *the protocol set up is UDP. After the header and packet are defined, the
+ *message is send at the appropriate port number and target IP.
+ *@param {String} streamID  Allows a user to select streams to Subscribe to.
+  If StreamID is not given, all streams are sent
+ *@param {String} data Refers to the data to be sent.
+ *@param {object} _header Is a JSON object that will be placed in the header
+    in general these could be arbitrary information,
+    however, several tags will be decoded
+  - stamp: the server will fill in the server time stamp
+  - limit: array of receiver ids, the server will send the packet only to these id's
+ *@module send
+ */
+
+// eslint-disable-next-line no-unused-vars
+function send(streamID, data, header) {
+  const headerSize = Buffer.alloc(8)
+  headerSize.writeUInt16LE(0, 0)
+  headerSize.writeUInt16LE(data.length, 2)
+  headerSize.writeUInt32LE(streamID, 4)
+  const packet = [headerSize, data]
+  const message = Buffer.concat(packet)
+  // TCP
+  if ((typeof senderStreams[streamID] !== 'undefined') && (senderStreams[streamID].protocol === 'tcp')) {
+    try {
+      senderStreams[streamID].client.write(message)
+    } catch (e) {
+      console.log('socket error', e)
+    }
+  }
+
+  // WS
+  if ((typeof senderStreams[streamID] !== 'undefined') && (senderStreams[streamID].protocol === 'ws')) {
+    try {
+      senderStreams[streamID].client.send(message)
+    } catch (e) {
+      console.log('socket error', e)
+    }
+  }
+
+  // UDP
+  if ((typeof senderStreams[streamID] !== 'undefined') && (senderStreams[streamID].protocol === 'udp')) {
+    // ToDo: add headers based on requirements (e.g. Stamp)
+    /*
+    let headerData = ''
+    if ((typeof header === 'object') && (header !== {})) headerData = JSON.stringify(header)
+    headerData = Buffer.from(header)
+    */
+    if (udpRegistered) {
+      udp.send(message, senderStreams[streamID].port, connConfig.ControlIP,
+        (err) => {
+          if (err) console.log('socket error', err)
+          else if (debug) console.log(`sent: h0,d${data.length}, none, ${connConfig.ControlIP}:${senderStreams[streamID].port}`)
+        })
+    } else console.log('UDP unregistered')
+  }
+
+  if (debug) console.log(`sent: ID${streamID} h${0},d${data.byteLength}`)
+}
+
+
+/**
+ *Requests a 'sender' function from Corelink protocol which  needs input like
+ *workspace,protocol,Source IP, token etc. The client awaits to read, after
+ *which it parses the JSON data. The statusCode checks for streamID,port,MTU
+ *and message in the content. After getting values for workspace,protocol,type
+ *and metadata, UDP protocol is set up. The function expects and object with the
+ *following parameters:
+ *@param {String} workspace Workspaces are used to separate out groups of streams
+  so that several independent groups of researchers can work together.
+ *@param {String} protocol  Protocol for the stream to use (UDP/TCP/WS)
+ *@param {String} type type information can be freely selected.But well known
+  formats will be published.At the moment those are 3d, audio.
+ *@param {String} metadata Information about data
+ *@param {String} from sender information
+ *@module createSender
+ */
+
+async function createSender(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('workspace' in workOptions)) reject(new Error('Workspace not found.'))
+    if (!('type' in workOptions)) reject(new Error('Type not defined.'))
+    if (!('protocol' in workOptions)) workOptions.protocol = 'udp'
+    if (!('metadata' in workOptions)) workOptions.metadata = ''
+    if (!('from' in workOptions)) workOptions.from = ''
+    if (!('alert' in workOptions)) workOptions.alert = false
+
+    const request = `{"function":"sender","workspace":"${workOptions.workspace}","proto":"${workOptions.protocol}","IP":"${sourceIP}","port":0,"alert":${workOptions.alert},"type":"${workOptions.type}","meta":${JSON.stringify(workOptions.metadata)},"from":"${workOptions.from}","token":"${token}"}`
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if (debug) console.log('CreateSender Result:', content)
+
+    if ('streamID' in content) senderStreams[content.streamID] = []
+    else reject(new Error('StreamID not found.'))
+    if ('port' in content) senderStreams[content.streamID].port = content.port
+    else reject(new Error('Target port not found.'))
+    if ('MTU' in content) senderStreams[content.streamID].MTU = content.MTU
+    else reject(new Error('Target MTU not found.'))
+
+    senderStreams[content.streamID].workspace = workOptions.workspace
+    senderStreams[content.streamID].protocol = workOptions.protocol
+    senderStreams[content.streamID].type = workOptions.type
+    senderStreams[content.streamID].metadata = workOptions.metadata
+    senderStreams[content.streamID].from = workOptions.from
+    senderStreams[content.streamID].alert = workOptions.alert
+    if (debug) console.log('create sender sender STream', senderStreams)
+
+    if ((workOptions.protocol === 'udp') && (!udpRegistered)) await setupUDP().catch((err) => { console.log(err) })
+    if (workOptions.protocol === 'ws') await senderSetupWS(content.streamID, content.port).catch((err) => { console.log(err) })
+    if (workOptions.protocol === 'tcp') await senderSetupTCP(content.streamID, content.port).catch((err) => { console.log(err) })
+
+    if (debug) console.log('createSender returns:', content.streamID)
+    resolve(content.streamID)
+  }))
+}
+
+
+/**
+ *It takes parameters streamID and port and requests a receiver function from
+ *Corelink protocol which has inputs workspace name, streamID,source IP,token etc.
+ *Further,it checks for statusCode,streamID,port,potocol,streamList,MTU. UDP
+ *protocol is the set up on receiver's side. The function expects and object with the
+ *following parameters:
+ *@param {String} workspace Workspaces are used to separate out groups of streams
+  so that several independent groups of researchers can work together.
+ *@param {String} protocol Protocol for the stream to use (UDP/TCP/WS)
+ *@param {String} streamIDs Allows a user to select streams to Subscribe to.
+  If StreamID is not given, all streams are sent
+ *@param {String} type type information can be freely selected.But well known
+  formats will be published.At the moment those are 3d, audio.
+ *@param {String} alert alert is an optional argument that false,if new streams
+  of this type are registered will send the streamID’s to the client via server
+  initiated controlFunction (default is false)
+ *@param {String} echo receive data that was sent by the same user (default is false)
+ *@param {String} receiverID Receiver streamID to remove streams from
+ *@module createReceiver
+ */
+
+async function createReceiver(options) {
+  return (new Promise((async (resolve, reject) => {
+    // checking inputs
+    const workOptions = options
+
+    if (!('workspace' in workOptions)) reject(new Error('Workspace not found.'))
+    if (!('protocol' in workOptions)) workOptions.protocol = 'udp'
+    if (!('streamIDs' in workOptions)) workOptions.streamIDs = []
+    if (!('type' in workOptions)) workOptions.type = []
+    if (!('alert' in workOptions)) workOptions.alert = false
+    if (!('echo' in workOptions)) workOptions.echo = false
+
+    const request = `{"function":"receiver","workspace":"${workOptions.workspace}","streamIDs":${JSON.stringify(workOptions.streamIDs)},"proto":"${workOptions.protocol}","IP":"${sourceIP}","port":0,"echo":${workOptions.echo},"alert":${workOptions.alert},"type":${JSON.stringify(workOptions.type)},"token":"${token}"}`
+    if (debug) console.log('createReceiver request', request)
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if (debug) console.log('create Receiver content', content)
+
+    if ('streamID' in content) receiverStream.streamID = content.streamID
+    else reject(new Error('StreamID not found.'))
+    if (debug) console.log(`createReceiver port: ${content.port}`)
+    if ('port' in content) receiverStream.port = content.port
+    else reject(new Error('Target port not found.'))
+    if ('proto' in content) receiverStream.proto = content.proto
+    else reject(new Error('Target proto not found.'))
+    if ('streamList' in content) receiverStream.streamList = content.streamList
+    else reject(new Error('Target streamList not found.'))
+    if ('MTU' in content) receiverStream.MTU = content.MTU
+    else reject(new Error('Target MTU not found.'))
+
+    receiverStream.workspace = workOptions.workspace
+    receiverStream.protocol = workOptions.protocol
+    receiverStream.type = workOptions.type
+    receiverStream.alert = workOptions.alert
+    receiverStream.echo = workOptions.echo
+
+    for (const stream in content.streamList) {
+      if (!allowedStreams.includes(content.streamList[stream].streamID)) {
+        allowedStreams.push(content.streamList[stream].streamID)
+      }
+    }
+
+    if ((workOptions.protocol === 'udp') && (udpRegistered)) receiverSetupUDP(content.streamID, content.port)
+    if ((workOptions.protocol === 'udp') && (!udpRegistered)) await setupUDP(content.streamID, content.port).catch((err) => { console.log(err) })
+    if (workOptions.protocol === 'tcp') await receiverSetupTCP(content.streamID, content.port).catch((err) => { console.log(err) })
+    if (workOptions.protocol === 'ws') await receiverSetupWS(content.streamID, content.port).catch((err) => { console.log(err) })
+
+    resolve(content.streamList)
+  })))
+}
+
+// Begin Common Functions
+
+/**
+ *set the debug variable to enable enhanced debug output
+ *@param {boolean} flag A boolen that will set the enhanced debug functionality
+ *@module setDebug
+ */
+
+function setDebug(flag) {
+  debug = flag
+}
+
+
+/**
+ *Login to the corelink server
+ *with username and password or token
+ *If the credentials are incorrect then it throws an error.
+ *The module ends with a
+  Promise. A promise is an object which can be returned synchronously from an asynchronous function.
+ *@param {String} credentials Refers to all login credentials like username,password and token.
+ *@module login
+ */
+
+async function login(credentials) {
+  return (new Promise(async (resolve, reject) => {
+    let request = ''
+    if ((typeof credentials.username === 'undefined')
+            && (typeof credentials.password === 'undefined')) {
+      if ((typeof credentials.token === 'undefined')) reject(new Error('Credentials not found.'))
+      else request = `{"function":"auth","token":"${credentials.token}"}`
+    } else request = `{"function":"auth","username":"${credentials.username}","password":"${credentials.password}"}`
+    if (debug) console.log('Login ', request)
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if (!content) return
+    if (debug) console.log('Login result ', content)
+    if ('token' in content) token = content.token
+    else reject(new Error('Token not found.'))
+    if ('IP' in content) sourceIP = content.IP
+    else reject(new Error('SourceIP not found.'))
+    resolve(true)
+  }))
+}
+
+
+/**
+ *Connects with client at the specified Port and IP number after verifying login credentials
+ *like username,password and token defined in the 'login' function.
+ *If the credentials are incorrect then it throws an error.
+ *The 'await' keyword waits for a value of ControlPort and ControlIP. The module ends with a
+  Promise. A promise is an object which can be returned synchronously from an asynchronous function.
+ *@param {String} credentials Refers to all login credentials like username,password and token.
+ *@param {String} config Refers to connection configuration like ControlPort and ControlIP
+
+ *@module connect
+ */
+
+async function connect(credentials, config, caPath = null) {
+  return (new Promise(async (resolve, reject) => {
+    if (debug) console.log('Connecting...')
+    connConfig = config
+
+    connCredentials = credentials
+
+    // dns.lookup(connConfig.ControlIP, (err, address) => {
+    //   connConfig.ControlIP = address
+    //   if (debug) console.log('address:', address)
+    // })
+
+    if (debug) console.log('Target IP:', connConfig.ControlIP, 'target port :', connConfig.ControlPort)
+    let conn
+    connected = true
+    // connect the client
+    await control.connect(connConfig.ControlIP, connConfig.ControlPort, caPath).catch((e) => {
+      connected = false
+      if (debug) console.log('not connectd', e)
+      reject(e)
+    })
+
+    if (connected) {
+      // check if there is a token and if it is valid
+      // checkToken()
+
+      // login if we dont have a good token
+      if (token == null) conn = await login(credentials).catch((e) => reject(e))
+
+      // if all streams are still valid
+      // if (conn) checkConnections()
+    }
+    if (conn) {
+      attempts = 1
+      resolve(conn)
+    } else reject(new Error('Problem loggin in'))
+  }))
+}
+
+/**
+ *Queries the corelink relay for available User
+ *@param {string} config the parameter name that should be set
+ *@param {string} context context that this cofiguration applies to global (server global
+                  settings), profile (global user specific settings), app (app global
+                  settings), or private (app user specific settings), if omitted or empty
+                  it is a global configuration parameter
+ *@param {string} app name of the app that this cofiguration applies to, can be omitted or
+                  empty for global or profile configuration parameters
+ *@param {string} plugin name of the plugin that this cofiguration applies to, can be omitted or
+                  empty for global or profile configuration parameters
+ *@param {string} user name of the user that this cofiguration applies to, can be omitted
+                  or empty for global or app configuration parameters, only an admin can
+                  set this parameter, otherwise the logged in username will be taken.'
+ *@param {string} value value to apply to the parameter, all parameters are stored as strings,
+                  but are applied in the defined type',
+ *@exports setConfig
+ *@module setConfig
+ */
+
+async function setConfig(options) {
+  return (new Promise(async (resolve, reject) => {
+    const request = options
+    if (!('config' in request)) { reject(new Error('Name of the configuration parameter required.')); return }
+    if (!('value' in request)) { reject(new Error('Context of the configuration parameter required.')); return }
+    if (!('context' in request) || (request === '')) { request.context = 'global' }
+    if (!('app' in request)) { request.app = '' }
+    if (!('plugin' in request)) { request.plugin = '' }
+    if (!('user' in request)) { request.user = '' }
+    request.function = 'setConfig'
+    request.token = token
+    console.log(request)
+    await control.request(request).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+// User management functions
+
+/**
+ *Queries the corelink relay to add a user
+ *@param {String} username  name that you would like to add
+ *@param {String} password  password of the user that you would like to add
+ *@param {String} email  emailid of the user that you would like to add
+ *@param {String} first  name that you would like to add
+ *@param {String} last  name that you would like to add
+ *@param {boolean} admin  admin property of the new user
+ *@exports addUser
+ *@module addUser
+ */
+
+async function addUser(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('username' in workOptions)) {
+      reject(new Error('user not found.'))
+      return
+    }
+    if (!('password' in workOptions)) {
+      reject(new Error('password not found.'))
+      return
+    }
+    if (!('email' in workOptions)) {
+      reject(new Error('email name not defined.'))
+      return
+    }
+    if (!('first' in workOptions)) workOptions.first = workOptions.username
+    if (!('last' in workOptions)) workOptions.last = workOptions.username
+    if (!('admin' in workOptions)) workOptions.admin = false
+    const request = `{"function":"addUser","username":"${workOptions.username}","password":"${workOptions.password}","first":"${workOptions.first}",
+    "email":"${workOptions.email}","last":"${workOptions.last}","admin":${workOptions.admin},"token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay to change the password of the user
+ *@param {String} password password that need to be change
+ *@exports password
+ *@module password
+ */
+async function password(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('password' in workOptions)) {
+      reject(new Error('password not found.'))
+      return
+    }
+    const request = `{"function":"password","password":"${workOptions.password}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay to remove a user
+ *@param {String} username  user name that you would like to remove
+ *@exports rmUser
+ *@module rmUser
+ */
+
+async function rmUser(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('username' in workOptions)) {
+      reject(new Error('username not given.'))
+      return
+    }
+    const request = `{"function":"rmUser","username":"${workOptions.username}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay for available User
+ *@returns {Array} Array of User, empty array if no User are available
+ *@exports listUsers
+ *@module listUsers
+ */
+
+async function listUsers() {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"listUsers","token":"${token}"}`
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if ('userList' in content) resolve(content.userList)
+    else reject(new Error('Users not found.'))
+  }))
+}
+
+// Group management functions:
+
+
+/**
+ *Queries the corelink relay to add a user to group(login user should either admin/ owner)
+ *@param {String} User  name that you would like to user to group
+ *@param {String} group  Groupname that will have a new user
+ *@module addUserGroup
+ */
+
+async function addUserGroup(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('username' in workOptions)) reject(new Error('user not found.'))
+    else if (!('group' in workOptions)) reject(new Error('group not found.'))
+    else {
+      const request = `{"function":"addUserGroup","username":"${workOptions.username}","group":"${workOptions.group}","token":"${token}"}`
+      await control.request(JSON.parse(request)).catch((e) => reject(e))
+    }
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay to remove user from group(login user should either admin/ owner)
+ *@param {String} User  name that you would like to user to group
+ *@param {String} group  Groupname that will have a new user
+ *@module rmUserGroup
+ */
+
+async function rmUserGroup(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('username' in workOptions)) reject(new Error('user not found.'))
+    else if (!('group' in workOptions)) reject(new Error('group not found.'))
+    else {
+      const request = `{"function":"rmUserGroup","user":"${workOptions.username}","group":"${workOptions.group}","token":"${token}"}`
+      await control.request(JSON.parse(request)).catch((e) => reject(e))
+    }
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay for available group
+ *@returns {Array} Array of group, empty array if no grou[] are available
+ *@exports listGroups
+ *@module listGroups
+ */
+async function listGroups() {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"listGroups","token":"${token}"}`
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if ('groupList' in content) resolve(content.groupList)
+    else reject(new Error('  groupList not found.'))
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to add a Group
+ *@param {String} Group Group name that you would like to add
+ *@param {String} owner owner name of the new group
+ *@exports addGroup
+ *@module addGroup
+ */
+async function addGroup(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    if (!('group' in workOptions)) {
+      reject(new Error('new groupname not found.'))
+      return
+    }
+    const request = `{"function":"addGroup","group":"${workOptions.group}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to remove a group
+ *@param {String} Group group name that you would like to remove
+ *@exports rmGroup
+ *@module rmGroup
+ */
+async function rmGroup(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('group' in workOptions)) {
+      reject(new Error('remove group not found.'))
+      return
+    }
+    const request = `{"function":"rmGroup","group":"${workOptions.group}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+/**
+ *Queries the corelink relay to change the ownerhip of group
+ *@param {String} Group group name that you would like to change owner
+  *@param {String} username user name that you would like to be owner
+ *@exports changeOwner
+ *@module changeOwner
+ */
+async function changeOwner(options) {
+  return (new Promise(async (resolve, reject) => {
+    const workOptions = options
+    // checking inputs
+    if (!('group' in workOptions)) {
+      reject(new Error('groupname not found.'))
+      return
+    }
+    if (!('username' in workOptions)) {
+      reject(new Error('username not found.'))
+      return
+    }
+    const request = `{"function":"changeOwner","group":"${workOptions.group}","username":"${workOptions.username}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+
+// Workspace management functions:
+
+/**
+ *Queries the corelink relay for available workspaces
+ *@returns {Array} Array of workspaces, empty array if no workspaces are available
+ *@exports listWorkspaces
+ *@module listWorkspaces
+ */
+async function listWorkspaces() {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"listWorkspaces","token":"${token}"}`
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if ('workspaceList' in content) resolve(content.workspaceList)
+    else reject(new Error('workspaceList not found.'))
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to add a workspace
+ *@param {String} workspace workspace name that you would like to add
+ *@exports addWorkspace
+ *@module addWorkspace
+ */
+async function addWorkspace(workspace) {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"addWorkspace","workspace":"${workspace}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to remove a workspaces
+ *@param {String} workspace workspace name that you would like to remove
+ *@exports rmWorkspace
+ *@module rmWorkspace
+ */
+async function rmWorkspace(workspace) {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"rmWorkspace","workspace":"${workspace}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to set a default workspace
+ *@param {String} workspace workspace name that you would like to set as default
+ *@exports setDefaultWorkspace
+ *@module setDefaultWorkspace
+ */
+async function setDefaultWorkspace(workspace) {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"setDefaultWorkspace","workspace":"${workspace}","token":"${token}"}`
+    await control.request(JSON.parse(request)).catch((e) => reject(e))
+    resolve(true)
+  }))
+}
+
+
+/**
+ *Queries the corelink relay to get the current default workspace
+ *@returns {String} workspace name that is currently set as default
+ *@exports getDefaultWorkspace
+ *@module getDefaultWorkspace
+ */
+async function getDefaultWorkspace() {
+  return (new Promise(async (resolve, reject) => {
+    const request = `{"function":"getDefaultWorkspace","token":"${token}"}`
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if ('workspace' in content) resolve(content.workspace)
+    else reject(new Error('No default workspace found.'))
+  }))
+}
+
+// introspect functions functions
+
+/**
+ *Queries the corelink relay for available functions
+ *@returns {Array} Array of functions that the server has available
+ *@exports listFunctions
+ *@module listFunctions
+ */
+
+async function listFunctions() {
+  return (new Promise(async (resolve, reject) => {
+    const request = {}
+    request.function = 'listFunctions'
+    request.token = token
+    const content = await control.request(request).catch((e) => reject(e))
+    if ('functionList' in content) resolve(content)
+    else reject(new Error('functionList not found.'))
+  }))
+}
+
+/**
+ *Queries the corelink relay for available functions
+ *@returns {object} the object has functionList which is an array of functions names that the
+                    server has available
+ *@exports listServerFunctions
+ *@module listServerFunctions
+ */
+
+async function listServerFunctions() {
+  return (new Promise(async (resolve, reject) => {
+    const request = {}
+    request.function = 'listServerFunctions'
+    request.token = token
+    const content = await control.request(request).catch((e) => reject(e))
+    if ('functionList' in content) resolve(content)
+    else reject(new Error('functionList not found.'))
+  }))
+}
+
+/**
+ *Queries a specific function to get its self descriptor
+ *@param {String} options Options object, it has to have a function name
+ *@returns {Object} JSON object that describes the function
+ *@exports describeFunction
+ *@module describeFunction
+ */
+
+async function describeFunction(options) {
+  return (new Promise(async (resolve, reject) => {
+    // checking inputs
+    if (typeof options !== 'object') reject(new Error('No object supplied.'))
+    if (!('functionName' in options)) reject(new Error('No function name found.'))
+
+    const request = {}
+    request.function = 'describeFunction'
+    request.functionName = options.functionName
+    request.token = token
+    const content = await control.request(request).catch((e) => reject(e))
+    if ('description' in content) resolve(content)
+    else reject(new Error('description not found.'))
+  }))
+}
+
+/**
+ *Queries a specific function to get its self descriptor
+ *@param {String} options Options object, it has to have a server function name
+ *@returns {Object} JSON object that describes the function
+ *@exports describeServerFunction
+ *@module describeServerFunction
+ */
+
+async function describeServerFunction(options) {
+  return (new Promise(async (resolve, reject) => {
+    // checking inputs
+    if (!('functionName' in options)) reject(new Error('No function name found.'))
+
+    const request = {}
+    request.function = 'describeServerFunction'
+    request.functionName = options.functionName
+    request.token = token
+    const content = await control.request(request).catch((e) => reject(e))
+    if ('description' in content) resolve(content)
+    else reject(new Error('description not found.'))
+  }))
+}
+
+/**
+ *Get the receiverID of the current active receiver
+ *@returns {String} receiverID Receiver streamID to remove streams from
+ *@module getReceiverID
+ */
+
+async function getReceiverID() {
+  return receiverStream.streamID
+}
+
+/**
+ *Queries the corelink relay for available functions
+ *@param {array} workspaces an array of workspaces to list streams, omitted or empty array
+                            will list all workspaces that a user has access to
+ *@param {array} types an array of types of streams to list
+ *@returns {object} with senderStreams and receiverStreams arrays
+ *@exports listStreams
+ *@module listStreams
+ */
+
+async function listStreams(options) {
+  return (new Promise(async (resolve, reject) => {
+    const request = options || {}
+    request.function = 'listStreams'
+    request.token = token
+    if (!('workspaces' in request)) request.workspaces = []
+    if (!('types' in request)) request.types = []
+    const content = await control.request(request).catch((e) => reject(e))
+    resolve(content)
+  }))
+}
+
+/**
+*In the request made, subscribe function from Corelink protocol is called which
+*gets the value of streamID and token. Further,the streamList array is checked
+*to see if it has target streamList.
+*@param {String} options objet. Allows a user to select streams to subscribe to.
+    The options object should hold and array of streamIDs. If streamIDs or options
+    is not given, all streams are sent
+*@module subscribe
+*/
+
+async function subscribe(options) {
+  return (new Promise(async (resolve, reject) => {
+    let workOptions
+    if (typeof options === 'undefined') workOptions = {}
+    else workOptions = options
+
+    if (!('streamIDs' in workOptions)) workOptions.streamIDs = []
+
+    const request = `{"function":"subscribe","receiverID":"${receiverStream.streamID}","streamIDs":${JSON.stringify(workOptions.streamIDs)},"token":"${token}"}`
+    if (debug) console.log('subscribe request', request)
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if (debug) console.log('subscribe json', content)
+
+    if ('streamList' in content) receiverStream.streamList = content.streamList
+    else reject(new Error('Target streamList not found.'))
+
+    for (const stream in content.streamList) {
+      if (!allowedStreams.includes(content.streamList[stream].streamID)) {
+        allowedStreams.push(content.streamList[stream].streamID)
+      }
+    }
+    if (debug) console.log('subscribe streamList', content.streamList)
+    resolve(content.streamList)
+  }))
+}
+
+
+/**
+*In the request made, subscribe function from Corelink protocol is called which
+*gets the value of streamID and token. Further,the streamList array is checked
+*to see if it has target streamList. The function expects an object with the
+*following parameters:
+*@param {array} streamIDs Allows a user to select streams to unsubscribe from.
+                          If streamIDs are not given or empty all are unsubscribed from
+*@module unsubscribe
+*/
+
+async function unsubscribe(options) {
+  return (new Promise(async (resolve, reject) => {
+    let workOptions
+    if (typeof options === 'undefined') workOptions = {}
+    else workOptions = options
+
+    if (!('streamIDs' in workOptions)) workOptions.streamIDs = []
+
+    const request = `{"function":"unsubscribe","receiverID":${receiverStream.streamID},"streamIDs":${JSON.stringify(workOptions.streamIDs)},"token":"${token}"}`
+    if (debug) console.log('unsubscribe request', request)
+    const content = await control.request(JSON.parse(request)).catch((e) => reject(e))
+    if (debug) console.log('unsubscribe json', content)
+
+    for (let i = 0; i < allowedStreams.length; i += 1) {
+      if (content.streamList.includes(allowedStreams[i])) delete allowedStreams[i]
+    }
+    resolve(content.streamList)
+  }))
+}
+
+
+/**
+*Function to register event handlers for specific events
+*@param {array} type type of event:
+  - receiver: calls back with new streams that are available
+  - sender: calls back with new streams that are subscribed
+  - stale: call back with streams that went stale for this receiver and can be unsubscribed
+  - dropped: calls back with streams that dropped the subscription for a sender
+  - close: the control connection was closed
+  - data: calls back when data has arrived with (streamID, data, header)
+*@param {array} cb a function with the corresponding callback
+*@module on
+*/
+
+const on = (async function on(type, cb) {
+  switch (type) {
+    case 'receiver':
+      receiverCb = cb
+      break
+    case 'sender':
+      senderCb = cb
+      break
+    case 'data':
+      dataCb = cb
+      break
+    case 'stale':
+      staleCb = cb
+      break
+    case 'dropped':
+      droppedCb = cb
+      break
+    case 'close':
+      closeCb = cb
+      break
+    default:
+      break
+  }
+})
+
+
+/**
+ *Queries server functions that dont need special parameters
+  *@param {object} options Options object,
+          if generic is called the function name and the parameters need to be in a JSON object according to
+          https://corelink.hpc.nyu.edu/documentation/server-documentation/client-initiated-control-functions
+ *@returns {Object} JSON object that contains the function result
+ *@exports generic
+ *@module generic
+ */
+
+async function generic(options) {
+  return (new Promise(async (resolve, reject) => {
+    // checking inputs
+    const workOptions = options
+    if (typeof workOptions !== 'object') reject(new Error('No object supplied.'))
+    if (!('function' in workOptions)) reject(new Error('No function name'))
+
+    // adding token to request
+    if (!workOptions.token) workOptions.token = token
+    if (debug) console.log(workOptions)
+    const content = await control.request(workOptions).catch((e) => reject(e))
+    if (content) resolve(content)
+    else reject(new Error('Wrong Expresions.'))
+  }))
+}
+
+
+/**
+ *Requests a disconnect streams
+ *@param {String} workspaces Workspaces are used to separate out groups of
+  streams so that several independent groups of researchers can work together.
+ *@param {String} types disconnect only streams of a particular type.
+ *@param {String} streamIDs Allows a user to select streams to Subscribe to. If
+  StreamID is not given, all streams are sent, the streamIDs have to be numbers
+ *@returns {object} in the object there will be the array streamList
+ *@module disconnect
+*/
+
+async function disconnect(options) {
+  return (new Promise(async (resolve, reject) => {
+    console.log('options', options)
+    const request = {}
+    request.types = []
+    request.workspaces = []
+    request.streamIDs = []
+
+    if (typeof options === 'object') {
+      if (('types' in options) && Array.isArray(options.types) && (options.types.length > 0)) request.types = request.types.concat(options.types)
+      if (('types' in options) && (typeof options.types === 'string')) request.types.push(options.types)
+      if (('workspaces' in options) && Array.isArray(options.workspaces) && (options.workspaces.length > 0)) request.workspaces = request.workspaces.concat(options.workspaces)
+      if (('workspaces' in options) && (typeof options.workspaces === 'string')) request.workspaces.push(options.workspaces)
+      if (('streamIDs' in options) && Array.isArray(options.streamIDs) && (options.streamIDs.length > 0)) request.streamIDs = request.streamIDs.concat(options.streamIDs)
+      if (('streamIDs' in options) && (typeof options.streamIDs === 'number')) request.streamIDs.push(options.streamIDs)
+    }
+    request.function = 'disconnect'
+    request.token = token
+
+    if (debug) console.log('disconnect request', request)
+    const content = await control.request(request).catch((e) => reject(e))
+    if (debug) console.log('disconnect content', content)
+    resolve(content)
+  }))
+}
+
+/**
+ *This module gets all local streamIDs and,checks if they are undefined and
+  pushes them. The connection then waits for a disconnect to occur.
+ *@param {String} resolve If all streamIDs are fetched successfully for a
+  successful disconnect
+ *@param {String} reject If all streamIDs are not fetched, an error message is displayed
+ *@module exit
+*/
+async function exit() {
+  console.log('Trying to exit.')
+  return (new Promise((async (resolve, reject) => {
+    // get all local streamID's
+    const streamIDs = []
+    if (typeof receiverStream.streamID !== 'undefined') streamIDs.push(receiverStream.streamID)
+    for (const streamID in senderStreams) if (streamID) streamIDs.push(parseInt(streamID, 10))
+    if (debug) console.log('Exit: Disconnect Request.')
+    const dis = await disconnect({ streamIDs }).catch((err) => reject(err))
+    if (dis === true) resolve(true)
+    else reject(dis)
+  })))
+}
+
+// End Common Functions
+
+process.on('SIGINT', async () => {
+  console.log('Termination request received.')
+  setTimeout(process.exit, 2000)
+  await exit().catch(process.exit)
+  process.exit()
+})
+
+// expose property debug, so programs can switch debug on if needed
+module.exports.debug = debug
+
+module.exports.on = on
+module.exports.connect = connect
+
+module.exports.setDebug = setDebug
+
+module.exports.generic = generic
+module.exports.addWorkspace = addWorkspace
+module.exports.rmWorkspace = rmWorkspace
+module.exports.setDefaultWorkspace = setDefaultWorkspace
+module.exports.getDefaultWorkspace = getDefaultWorkspace
+module.exports.listWorkspaces = listWorkspaces
+module.exports.listFunctions = listFunctions
+module.exports.listServerFunctions = listServerFunctions
+module.exports.describeFunction = describeFunction
+module.exports.describeServerFunction = describeServerFunction
+module.exports.createSender = createSender
+module.exports.send = send
+module.exports.subscribe = subscribe
+module.exports.unsubscribe = unsubscribe
+module.exports.disconnect = disconnect
+module.exports.createReceiver = createReceiver
+module.exports.getReceiverID = getReceiverID
+module.exports.exit = exit
+module.exports.login = login
+module.exports.setConfig = setConfig
+module.exports.listStreams = listStreams
+
+
+// user funtions:
+module.exports.listUsers = listUsers
+module.exports.rmUser = rmUser
+module.exports.addUser = addUser
+module.exports.password = password
+
+// group functions:
+module.exports.listGroups = listGroups
+module.exports.rmGroup = rmGroup
+module.exports.addGroup = addGroup
+module.exports.addUserGroup = addUserGroup
+module.exports.rmUserGroup = rmUserGroup
+module.exports.changeOwner = changeOwner

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,12 +7,224 @@
     "": {
       "name": "exp-orchestrator-scripts",
       "version": "0.1.0",
-      "optionalDependencies": {
-        "@corelinkhub/corelink-client": "^5.1.2"
+      "dependencies": {
+        "websocket": "^1.0.34",
+        "ws": "^8.12.1"
       }
     },
-    "node_modules/@corelinkhub/corelink-client": {
-      "optional": true
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/websocket": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.63",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.32"
+      }
     }
   }
 }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "exp-orchestrator-scripts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "exp-orchestrator-scripts",
+      "version": "0.1.0",
+      "optionalDependencies": {
+        "@corelinkhub/corelink-client": "^5.1.2"
+      }
+    },
+    "node_modules/@corelinkhub/corelink-client": {
+      "optional": true
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "exp-orchestrator-scripts",
+  "version": "0.1.0",
+  "description": "Node sender/receiver scripts for the auto-connect demo",
+  "private": true,
+  "scripts": {
+    "test": "node --test 'lib/__tests__/**/*.test.js'"
+  },
+  "dependencies": {},
+  "optionalDependencies": {
+    "@corelinkhub/corelink-client": "^5.1.2"
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "node --test 'lib/__tests__/**/*.test.js'"
   },
-  "dependencies": {},
-  "optionalDependencies": {
-    "@corelinkhub/corelink-client": "^5.1.2"
+  "dependencies": {
+    "websocket": "^1.0.34",
+    "ws": "^8.12.1"
   }
 }

--- a/scripts/receiver.js
+++ b/scripts/receiver.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Standalone receiver that auto-connects via corelink (default) or relay.
+ * Usage: node receiver.js <deploy_id> [--mode corelink|relay] [--host URL]
+ */
+
+function parseArgs(argv) {
+  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const positional = []
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === '--mode') args.mode = argv[++i]
+    else if (a === '--host') args.host = argv[++i]
+    else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
+    else positional.push(a)
+  }
+  if (positional.length !== 1) {
+    console.error('usage: receiver.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    process.exit(2)
+  }
+  args.deployId = positional[0]
+  return args
+}
+
+async function fetchCredentials(host, deployId, role) {
+  const url = `${host}/deployments/${deployId}/credentials?role=${role}`
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    console.error(`Error fetching credentials: ${resp.status} ${await resp.text()}`)
+    process.exit(1)
+  }
+  return resp.json()
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const transport = args.mode === 'corelink'
+    ? require('./lib/corelink-transport')
+    : require('./lib/relay-transport')
+
+  console.log(`Mode: ${args.mode}`)
+  const cred = await fetchCredentials(args.host, args.deployId, 'receiver')
+
+  let handle
+  try {
+    handle = await transport.connect({
+      host: args.host,
+      deployId: args.deployId,
+      role: 'receiver',
+      credentials: cred.credentials,
+      corelinkBlock: cred.corelink,
+    })
+  } catch (e) {
+    console.error(`Connect failed (${args.mode}): ${e.message}`)
+    if (args.mode === 'corelink') console.error('Try --mode relay as a fallback.')
+    process.exit(1)
+  }
+
+  console.log(`Receiver connected (deployment: ${args.deployId})`)
+  console.log('Listening for messages (Ctrl+C to quit)...\n')
+
+  await transport.subscribe(handle, (msg) => {
+    console.log(`[received] ${msg}`)
+  })
+
+  // Keep alive
+  process.on('SIGINT', async () => {
+    await transport.close(handle).catch(() => {})
+    console.log('\nDone.')
+    process.exit(0)
+  })
+  await new Promise(() => {})
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/scripts/receiver.js
+++ b/scripts/receiver.js
@@ -5,17 +5,18 @@
  */
 
 function parseArgs(argv) {
-  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const args = { mode: 'corelink', host: 'http://localhost:8000', corelinkHost: null }
   const positional = []
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i]
     if (a === '--mode') args.mode = argv[++i]
     else if (a === '--host') args.host = argv[++i]
+    else if (a === '--corelink-host') args.corelinkHost = argv[++i]
     else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
     else positional.push(a)
   }
   if (positional.length !== 1) {
-    console.error('usage: receiver.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    console.error('usage: receiver.js <deploy_id> [--mode corelink|relay] [--host URL] [--corelink-host HOST]')
     process.exit(2)
   }
   args.deployId = positional[0]
@@ -41,6 +42,12 @@ async function main() {
   console.log(`Mode: ${args.mode}`)
   const cred = await fetchCredentials(args.host, args.deployId, 'receiver')
 
+  // Allow CLI override of the corelink host (useful when the plugin container
+  // and the host process need different hostnames to reach the same server).
+  const corelinkBlock = cred.corelink && args.corelinkHost
+    ? { ...cred.corelink, host: args.corelinkHost }
+    : cred.corelink
+
   let handle
   try {
     handle = await transport.connect({
@@ -48,7 +55,7 @@ async function main() {
       deployId: args.deployId,
       role: 'receiver',
       credentials: cred.credentials,
-      corelinkBlock: cred.corelink,
+      corelinkBlock,
     })
   } catch (e) {
     console.error(`Connect failed (${args.mode}): ${e.message}`)

--- a/scripts/run_receiver.js.sh
+++ b/scripts/run_receiver.js.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d node_modules ]; then
+  npm install --silent
+fi
+
+exec node receiver.js "$@"

--- a/scripts/run_sender.js.sh
+++ b/scripts/run_sender.js.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -d node_modules ]; then
+  npm install --silent
+fi
+
+exec node sender.js "$@"

--- a/scripts/sender.js
+++ b/scripts/sender.js
@@ -7,17 +7,18 @@
 const readline = require('readline')
 
 function parseArgs(argv) {
-  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const args = { mode: 'corelink', host: 'http://localhost:8000', corelinkHost: null }
   const positional = []
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i]
     if (a === '--mode') args.mode = argv[++i]
     else if (a === '--host') args.host = argv[++i]
+    else if (a === '--corelink-host') args.corelinkHost = argv[++i]
     else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
     else positional.push(a)
   }
   if (positional.length !== 1) {
-    console.error('usage: sender.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    console.error('usage: sender.js <deploy_id> [--mode corelink|relay] [--host URL] [--corelink-host HOST]')
     process.exit(2)
   }
   args.deployId = positional[0]
@@ -43,6 +44,12 @@ async function main() {
   console.log(`Mode: ${args.mode}`)
   const cred = await fetchCredentials(args.host, args.deployId, 'sender')
 
+  // Allow CLI override of the corelink host (useful when the plugin container
+  // and the host process need different hostnames to reach the same server).
+  const corelinkBlock = cred.corelink && args.corelinkHost
+    ? { ...cred.corelink, host: args.corelinkHost }
+    : cred.corelink
+
   let handle
   try {
     handle = await transport.connect({
@@ -50,7 +57,7 @@ async function main() {
       deployId: args.deployId,
       role: 'sender',
       credentials: cred.credentials,
-      corelinkBlock: cred.corelink,
+      corelinkBlock,
     })
   } catch (e) {
     console.error(`Connect failed (${args.mode}): ${e.message}`)

--- a/scripts/sender.js
+++ b/scripts/sender.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Standalone sender that auto-connects via corelink (default) or relay.
+ * Usage: node sender.js <deploy_id> [--mode corelink|relay] [--host URL]
+ */
+
+const readline = require('readline')
+
+function parseArgs(argv) {
+  const args = { mode: 'corelink', host: 'http://localhost:8000' }
+  const positional = []
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === '--mode') args.mode = argv[++i]
+    else if (a === '--host') args.host = argv[++i]
+    else if (a.startsWith('--')) { console.error(`unknown flag: ${a}`); process.exit(2) }
+    else positional.push(a)
+  }
+  if (positional.length !== 1) {
+    console.error('usage: sender.js <deploy_id> [--mode corelink|relay] [--host URL]')
+    process.exit(2)
+  }
+  args.deployId = positional[0]
+  return args
+}
+
+async function fetchCredentials(host, deployId, role) {
+  const url = `${host}/deployments/${deployId}/credentials?role=${role}`
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    console.error(`Error fetching credentials: ${resp.status} ${await resp.text()}`)
+    process.exit(1)
+  }
+  return resp.json()
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const transport = args.mode === 'corelink'
+    ? require('./lib/corelink-transport')
+    : require('./lib/relay-transport')
+
+  console.log(`Mode: ${args.mode}`)
+  const cred = await fetchCredentials(args.host, args.deployId, 'sender')
+
+  let handle
+  try {
+    handle = await transport.connect({
+      host: args.host,
+      deployId: args.deployId,
+      role: 'sender',
+      credentials: cred.credentials,
+      corelinkBlock: cred.corelink,
+    })
+  } catch (e) {
+    console.error(`Connect failed (${args.mode}): ${e.message}`)
+    if (args.mode === 'corelink') console.error('Try --mode relay as a fallback.')
+    process.exit(1)
+  }
+
+  console.log(`Sender connected (deployment: ${args.deployId})`)
+  console.log('Type messages to send (Ctrl+C to quit):\n')
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  rl.setPrompt('> ')
+  rl.prompt()
+  rl.on('line', async (line) => {
+    if (line) {
+      try {
+        await transport.send(handle, line)
+        console.log(`  sent: ${line}`)
+      } catch (e) {
+        console.error(`  send error: ${e.message}`)
+      }
+    }
+    rl.prompt()
+  })
+  rl.on('close', async () => {
+    await transport.close(handle).catch(() => {})
+    console.log('\nDone.')
+    process.exit(0)
+  })
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Summary
- Auto-connect demo (sender → plugin → receiver) now runs end-to-end over Corelink, with all Corelink-touching code isolated behind a clean modular boundary so the post-demo rip-out is a small enumerated set of file deletes.
- Backend's `POST /deploy/execute/v2` mints a `deploy_id`, calls a new HTTP provisioning endpoint on the corelink-server, threads the result into the deploy planner, and adds `DELETE /deployments/{id}` for cleanup.
- Frontend deploy bridge now drives the full pipeline (executor=local + inject_env=true) so the canvas-deploy button launches the plugin container with `CORELINK_*` env vars injected.

## What landed
**Spec & plan** (`docs/superpowers/`):
- `specs/2026-04-27-corelink-modular-demo-design.md` — the architectural spec (Variant A: provisioning HTTP API on corelink-server, single workspace per deployment, rip-out checklist enumerated).
- `plans/2026-04-27-corelink-modular-demo.md` — the 25-task implementation plan.

**Backend** (Python / FastAPI):
- New `corelink_admin.py` — thin `httpx`-based client for the corelink-server `/api/provision` routes (`provision_deployment`, `unprovision_deployment`). Single rip-out file.
- `deployment.py` — new `deploy_id` / `workspace` / `corelink_creds` parameters; `CORELINK_*` env vars injected into plugin-node `env_plan` only.
- `main.py` — provisioning call before planner, `corelink` block in `/credentials` response with role→user mapping (sender→Testuser1, receiver→Testuser2, plugin→Testuser to dodge corelink's same-user notification suppression), best-effort `DELETE /deployments/{id}`.
- `run.sh` — `CORELINK_PROVISION_TOKEN` replaces `CORELINK_USERNAME`/`PASSWORD` (creds now come from provisioning response).
- `config/allowed_images.json` — allows `corelink_demo:latest`.

**corelink-server provisioning routes** (separate repo `corelink-server` on branch `feature/provisioning-api` — 6 commits, not part of this PR):
- `POST /api/provision` (creates `workflow_<deploy_id>` workspace, admin-owned, idempotent).
- `DELETE /api/provision/<id>` (idempotent removal).
- `X-Provision-Token` header auth, JSON body parsing, URL-parsing fix to strip query strings.

**Plugin** (`plugins/corelink_demo/`):
- New Python plugin Docker image (mirrors `reference_plugin` with a real uppercase transform).
- `_on_data` / `_on_stream_update` callbacks correctly subscribe to late-arriving senders via `subscribe_to_stream(receiver_id, stream_id)` (Python corelink's API; differs from the JS lib).
- Dockerfile uses `PYTHONUNBUFFERED=1` for live log visibility, runs as non-root `appuser`.

**Node sender/receiver scripts** (`scripts/`):
- `lib/corelink-transport.js` — vendored copy of `corelink.lib.js` (NYU client), TLS bypass, subscribes to streams in initial `streamList` plus alert-arrived senders.
- `lib/relay-transport.js` — long-term post-Corelink fallback path.
- `sender.js` / `receiver.js` CLIs with `--mode corelink|relay` (default corelink) and `--corelink-host` override (needed because plugin reaches corelink via `host.docker.internal` while host scripts use `127.0.0.1`).
- Interface-conformance test verifies both transports export the same shape.

**Frontend** (`frontend/app/api/deploy/route.ts`):
- Defaults flipped to `executor=local&inject_env=true` so the canvas-deploy button drives the full pipeline. Per-request override via `?executor=...&inject_env=...` query string still supported for dry-run.

## Modular boundary

To rip Corelink out post-demo:
- **Delete**: `backend/corelink_admin.py`, `backend/corelink_health.py`, `backend/tests/test_corelink_admin.py`, `backend/tests/test_corelink_health.py`, `plugins/corelink_demo/`, `plugins/reference_plugin/`, `scripts/lib/corelink-transport.js`, `scripts/lib/vendor/`, the corelink-server provisioning routes.
- **Edit**: 4 small surgical edits in `backend/main.py`, `backend/allocator.py`, `backend/deployment.py`, `backend/run.sh`. Drop the `corelink` block in `/credentials` response. Drop the `--mode corelink` ternary in sender.js/receiver.js. Drop the corelink-client deps in `scripts/package.json`.

## Test plan
- [x] Backend unit/integration: 89 pytest tests pass (corelink_admin happy/timeout/401/5xx, planner threading + CORELINK env injection, /deploy/execute/v2 provisioning + 503-on-failure + DELETE).
- [x] Node tests: 3 transport tests pass (relay-transport interface + send, corelink/relay interface conformance).
- [x] Plugin transform: 3 unit tests pass (uppercase, empty input, non-UTF-8 passthrough).
- [x] Live end-to-end (corelink mode): `[received] HELLO` confirmed in receiver after sender posts "hello", with workspace+plugin lifecycle full round-trip including DELETE cleanup.
- [x] Live end-to-end (relay mode regression): `[received] hello-relay` confirmed.
- [ ] Live end-to-end via the web app's deploy button (manual; runbook in PR thread).

## Known limitations parked for after the demo
- **corelink-server v6.0.0.3** has an internal `ERR_OUT_OF_RANGE` in its stream-relay accounting that triggers after accumulated state. Workaround: full-restart corelink-server between demo runs. Root cause is in the corelink-server repo, not this codebase.
- `/credentials` endpoint returns the corelink password in cleartext with no AuthN/AuthZ. Documented inline at the storage site as `# NOTE: demo-only`. Pre-prod must gate or scrub.
- TLS verification disabled (`verify=False` in Python httpx, `NODE_TLS_REJECT_UNAUTHORIZED=0` in Node) — corelink-server uses self-signed dev cert. Pre-prod hardening item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)