### PR TITLE
feat: add React error boundaries (#50)

### DIFF
--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -3,11 +3,16 @@
 import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import MinimalCanvas from "@/components/canvas/MinimalCanvas";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 function CreateContent() {
   const searchParams = useSearchParams();
   const projectId = searchParams.get('project');
-  return <MinimalCanvas projectId={projectId} />;
+  return (
+    <ErrorBoundary label="MinimalCanvas">
+      <MinimalCanvas projectId={projectId} />
+    </ErrorBoundary>
+  );
 }
 
 export default function CreatePage() {

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Route error', { digest: error.digest, error });
+  }, [error]);
+
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+        padding: '24px',
+        background: 'var(--paper, #fafafa)',
+        color: 'var(--ink, #222)',
+        fontFamily: 'var(--font-inter-tight), system-ui, sans-serif',
+      }}
+    >
+      <h1 style={{ fontSize: '20px', fontWeight: 600 }}>Something went wrong</h1>
+      <p style={{ fontSize: '14px', opacity: 0.8, maxWidth: '480px', textAlign: 'center' }}>
+        {error.message || 'An unexpected error occurred.'}
+      </p>
+      <button
+        onClick={reset}
+        style={{
+          padding: '8px 16px',
+          border: '1px solid currentColor',
+          borderRadius: '4px',
+          background: 'transparent',
+          color: 'inherit',
+          cursor: 'pointer',
+          fontSize: '14px',
+        }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Global error', { digest: error.digest, error });
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          minHeight: '100vh',
+          margin: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '12px',
+          padding: '24px',
+          background: '#fafafa',
+          color: '#222',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <h1 style={{ fontSize: '20px', fontWeight: 600 }}>The app crashed</h1>
+        <p style={{ fontSize: '14px', opacity: 0.8, maxWidth: '480px', textAlign: 'center' }}>
+          {error.message || 'An unexpected error occurred.'}
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            padding: '8px 16px',
+            border: '1px solid currentColor',
+            borderRadius: '4px',
+            background: 'transparent',
+            color: 'inherit',
+            cursor: 'pointer',
+            fontSize: '14px',
+          }}
+        >
+          Reload
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React from 'react';
+
+type Props = {
+  children: React.ReactNode;
+  fallback?: (error: Error, reset: () => void) => React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  label?: string;
+};
+
+type State = { error: Error | null };
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    const label = this.props.label ?? 'ErrorBoundary';
+    console.error('ErrorBoundary caught error', { label, error, componentStack: info.componentStack });
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    if (this.props.fallback) return this.props.fallback(error, this.reset);
+
+    return (
+      <div
+        role="alert"
+        style={{
+          padding: '24px',
+          margin: '16px',
+          border: '1px solid var(--ink, #222)',
+          borderRadius: '6px',
+          background: 'var(--paper, #fafafa)',
+          color: 'var(--ink, #222)',
+          fontFamily: 'var(--font-inter-tight), system-ui, sans-serif',
+        }}
+      >
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: '8px' }}>
+          Something went wrong
+        </h2>
+        <p style={{ fontSize: '14px', opacity: 0.8, marginBottom: '12px' }}>
+          {error.message || 'An unexpected error occurred.'}
+        </p>
+        <button
+          onClick={this.reset}
+          style={{
+            padding: '6px 14px',
+            border: '1px solid currentColor',
+            borderRadius: '4px',
+            background: 'transparent',
+            color: 'inherit',
+            cursor: 'pointer',
+            fontSize: '13px',
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
Three layers of error containment so a single component crash no longer takes down the page:
- **`components/ErrorBoundary.tsx`** — reusable class boundary with retry, accepts a custom fallback.
- **`app/create/page.tsx`** — wraps `MinimalCanvas` so a node-render crash doesn't kill the canvas route.
- **`app/error.tsx` & `app/global-error.tsx`** — Next App Router native fallbacks for route- and root-level errors.

Closes #50.

> Stacked on top of #75 (which is stacked on #74). Re-target main as the chain merges.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual: throw inside a custom node, confirm fallback UI renders with a working Reset button instead of the page going blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)