### PR TITLE
fix: support fan-out and fan-in by keying creds on (peer_id, stream_type)

### DIFF
--- a/backend/deployment.py
+++ b/backend/deployment.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 import tempfile
-from collections import deque
+from collections import defaultdict, deque
 from typing import Any, Deque, Dict, List, Tuple
 
 from dag import topological_order
@@ -61,8 +61,9 @@ def process_workflow(
             )
 
         cred = generate_pub_sub_cred(stream_type, src, dst, workspace, deploy_id)
-        src.out_creds[stream_type] = cred
-        dst.in_creds[stream_type] = cred
+        # Each side records the OPPOSITE end as the peer.
+        src.out_creds.append(cred.model_copy(update={"peer_id": dst.id}))
+        dst.in_creds.append(cred.model_copy(update={"peer_id": src.id}))
 
     return 200
 
@@ -100,21 +101,49 @@ def generate_pub_sub_cred(
 
 
 def build_env_vars(node: DeployNode) -> Dict[str, str]:
+    """Emit env vars for every inbound and outbound edge.
+
+    Each cred is keyed by both stream type AND peer node id, so a node with
+    multiple inputs of the same type (fan-in) or multiple outputs of the same
+    type (fan-out) gets one env var per edge:
+
+        IN_<TYPE>_FROM_<PEER>_STREAM_ID   (and _WORKSPACE / _PROTOCOL)
+        OUT_<TYPE>_TO_<PEER>_STREAM_ID
+
+    Plugins that pattern-match on `IN_*_STREAM_ID` / `OUT_*_STREAM_ID` (the
+    convention) keep working unchanged. For plugins that want to enumerate
+    peers without parsing var names, we also emit:
+
+        IN_<TYPE>_PEERS=peerA,peerB
+        OUT_<TYPE>_PEERS=peerC
+    """
     env_vars = dict(node.env_vars)
     env_vars["NODE_ID"] = node.id
     env_vars["NODE_TYPE"] = node.type
 
-    for stream_type, cred in node.in_creds.items():
-        stream_key = _normalize_env_key(stream_type)
-        env_vars[f"IN_{stream_key}_STREAM_ID"] = cred.stream_id
-        env_vars[f"IN_{stream_key}_WORKSPACE"] = cred.workspace
-        env_vars[f"IN_{stream_key}_PROTOCOL"] = cred.protocol
+    in_peers_by_type: Dict[str, List[str]] = defaultdict(list)
+    out_peers_by_type: Dict[str, List[str]] = defaultdict(list)
 
-    for stream_type, cred in node.out_creds.items():
-        stream_key = _normalize_env_key(stream_type)
-        env_vars[f"OUT_{stream_key}_STREAM_ID"] = cred.stream_id
-        env_vars[f"OUT_{stream_key}_WORKSPACE"] = cred.workspace
-        env_vars[f"OUT_{stream_key}_PROTOCOL"] = cred.protocol
+    for cred in node.in_creds:
+        type_key = _normalize_env_key(cred.data_type)
+        peer_key = _normalize_env_key(cred.peer_id)
+        env_vars[f"IN_{type_key}_FROM_{peer_key}_STREAM_ID"] = cred.stream_id
+        env_vars[f"IN_{type_key}_FROM_{peer_key}_WORKSPACE"] = cred.workspace
+        env_vars[f"IN_{type_key}_FROM_{peer_key}_PROTOCOL"] = cred.protocol
+        in_peers_by_type[type_key].append(peer_key)
+
+    for cred in node.out_creds:
+        type_key = _normalize_env_key(cred.data_type)
+        peer_key = _normalize_env_key(cred.peer_id)
+        env_vars[f"OUT_{type_key}_TO_{peer_key}_STREAM_ID"] = cred.stream_id
+        env_vars[f"OUT_{type_key}_TO_{peer_key}_WORKSPACE"] = cred.workspace
+        env_vars[f"OUT_{type_key}_TO_{peer_key}_PROTOCOL"] = cred.protocol
+        out_peers_by_type[type_key].append(peer_key)
+
+    for type_key, peers in in_peers_by_type.items():
+        env_vars[f"IN_{type_key}_PEERS"] = ",".join(peers)
+    for type_key, peers in out_peers_by_type.items():
+        env_vars[f"OUT_{type_key}_PEERS"] = ",".join(peers)
 
     return env_vars
 
@@ -208,11 +237,11 @@ def deploy(
         inject_vars_to_image(env_vars, image_name)
         injected_nodes.append(node.id)
 
-    creds_by_node: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]] = {}
+    creds_by_node: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
     for node_id, node in nodes_by_id.items():
         creds_by_node[node_id] = {
-            "in_creds": {stream: cred.model_dump() for stream, cred in node.in_creds.items()},
-            "out_creds": {stream: cred.model_dump() for stream, cred in node.out_creds.items()},
+            "in_creds": [cred.model_dump() for cred in node.in_creds],
+            "out_creds": [cred.model_dump() for cred in node.out_creds],
         }
 
     return {

--- a/backend/tests/test_deployment_planner.py
+++ b/backend/tests/test_deployment_planner.py
@@ -56,24 +56,32 @@ def test_deploy_returns_deterministic_idempotent_plan(linear_workflow: DeployWor
     assert plugin_a_env["EXISTING"] == "1"
     assert plugin_a_env["NODE_ID"] == "plugin-a"
     assert plugin_a_env["NODE_TYPE"] == "plugin"
-    assert plugin_a_env["IN_JSON_STREAM_ID"] == "deploy.abc12345.source_plugin-a_json"
-    assert plugin_a_env["OUT_BYTES_STREAM_ID"] == "deploy.abc12345.plugin-a_plugin-b_bytes"
+    assert plugin_a_env["IN_JSON_FROM_SOURCE_STREAM_ID"] == "deploy.abc12345.source_plugin-a_json"
+    assert plugin_a_env["OUT_BYTES_TO_PLUGIN_B_STREAM_ID"] == "deploy.abc12345.plugin-a_plugin-b_bytes"
+    assert plugin_a_env["IN_JSON_PEERS"] == "SOURCE"
+    assert plugin_a_env["OUT_BYTES_PEERS"] == "PLUGIN_B"
 
     plugin_b_env = first["env_plan"]["plugin-b"]
     assert plugin_b_env["PLUGIN_B"] == "ready"
-    assert plugin_b_env["IN_BYTES_STREAM_ID"] == "deploy.abc12345.plugin-a_plugin-b_bytes"
+    assert plugin_b_env["IN_BYTES_FROM_PLUGIN_A_STREAM_ID"] == "deploy.abc12345.plugin-a_plugin-b_bytes"
+    assert plugin_b_env["IN_BYTES_PEERS"] == "PLUGIN_A"
 
-    assert first["credentials_by_node"]["source"]["out_creds"]["json"]["workspace"] == (
-        "workflow_abc12345"
-    )
+    source_out = first["credentials_by_node"]["source"]["out_creds"]
+    assert isinstance(source_out, list) and len(source_out) == 1
+    assert source_out[0]["workspace"] == "workflow_abc12345"
+    assert source_out[0]["peer_id"] == "plugin-a"
+    assert source_out[0]["data_type"] == "json"
+
     # Every credential in the plan uses the same deploy-scoped workspace
     for node_creds in first["credentials_by_node"].values():
-        for stream_creds in (node_creds["in_creds"], node_creds["out_creds"]):
-            for cred in stream_creds.values():
+        for cred_list in (node_creds["in_creds"], node_creds["out_creds"]):
+            for cred in cred_list:
                 assert cred["workspace"] == "workflow_abc12345"
-    assert first["credentials_by_node"]["plugin-b"]["in_creds"]["bytes"]["stream_id"] == (
-        "deploy.abc12345.plugin-a_plugin-b_bytes"
-    )
+
+    plugin_b_in = first["credentials_by_node"]["plugin-b"]["in_creds"]
+    assert len(plugin_b_in) == 1
+    assert plugin_b_in[0]["stream_id"] == "deploy.abc12345.plugin-a_plugin-b_bytes"
+    assert plugin_b_in[0]["peer_id"] == "plugin-a"
 
 
 @pytest.mark.parametrize(
@@ -140,8 +148,10 @@ def test_deploy_infers_streams_when_edge_contract_is_present() -> None:
     result = deployment.deploy(workflow, deploy_id="test", workspace="workflow_test")
 
     assert result["topological_order"] == ["source", "plugin-a"]
-    assert result["env_plan"]["plugin-a"]["IN_PARQUET_STREAM_ID"] == "deploy.test.source_plugin-a_parquet"
-    assert result["credentials_by_node"]["source"]["out_creds"]["parquet"]["data_type"] == "parquet"
+    assert result["env_plan"]["plugin-a"]["IN_PARQUET_FROM_SOURCE_STREAM_ID"] == "deploy.test.source_plugin-a_parquet"
+    source_out = result["credentials_by_node"]["source"]["out_creds"]
+    assert source_out[0]["data_type"] == "parquet"
+    assert source_out[0]["peer_id"] == "plugin-a"
 
 
 def test_deploy_injects_env_only_for_plugins_with_images(
@@ -161,8 +171,8 @@ def test_deploy_injects_env_only_for_plugins_with_images(
     assert result["skipped_nodes"] == [
         {"node_id": "plugin-b", "reason": "No runtime/container image found"}
     ]
-    assert injected[0][1]["IN_JSON_STREAM_ID"] == "deploy.test.source_plugin-a_json"
-    assert injected[0][1]["OUT_BYTES_STREAM_ID"] == "deploy.test.plugin-a_plugin-b_bytes"
+    assert injected[0][1]["IN_JSON_FROM_SOURCE_STREAM_ID"] == "deploy.test.source_plugin-a_json"
+    assert injected[0][1]["OUT_BYTES_TO_PLUGIN_B_STREAM_ID"] == "deploy.test.plugin-a_plugin-b_bytes"
 
 
 def test_inject_vars_to_image_uses_disposable_compose_file(
@@ -181,7 +191,7 @@ def test_inject_vars_to_image_uses_disposable_compose_file(
     monkeypatch.setattr(deployment.subprocess, "run", fake_run)
 
     deployment.inject_vars_to_image(
-        {"NODE_ID": "plugin-a", "IN_JSON_STREAM_ID": "stream-1"},
+        {"NODE_ID": "plugin-a", "IN_JSON_FROM_SOURCE_STREAM_ID": "stream-1"},
         "repo/image:latest",
     )
 
@@ -190,7 +200,7 @@ def test_inject_vars_to_image_uses_disposable_compose_file(
     assert captured["exists_during_run"] is True
     assert "image: repo/image:latest" in captured["content"]
     assert "- NODE_ID=plugin-a" in captured["content"]
-    assert "- IN_JSON_STREAM_ID=stream-1" in captured["content"]
+    assert "- IN_JSON_FROM_SOURCE_STREAM_ID=stream-1" in captured["content"]
     assert not compose_file.exists()
 
 
@@ -221,3 +231,102 @@ def test_broker_env_omitted_when_creds_not_provided(linear_workflow: DeployWorkf
     plugin_a = plan["env_plan"]["plugin-a"]
     assert "NATS_URL" not in plugin_a
     assert "NATS_TOKEN" not in plugin_a
+
+
+def test_fan_out_same_stream_type_keeps_both_subjects() -> None:
+    """One sender publishing the same stream type to two receivers must yield
+    two distinct OUT subjects on the source. Regression test for #78."""
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="src", type="sender", out_streams=["json"]),
+            DeployNode(id="dst-a", type="plugin", in_streams=["json"]),
+            DeployNode(id="dst-b", type="plugin", in_streams=["json"]),
+        ],
+        edges=[
+            DeployEdge(source="src", target="dst-a", data="json"),
+            DeployEdge(source="src", target="dst-b", data="json"),
+        ],
+    )
+
+    plan = deployment.deploy(workflow, deploy_id="dep", workspace="ws")
+    src_out = plan["credentials_by_node"]["src"]["out_creds"]
+    assert len(src_out) == 2
+    assert {c["peer_id"] for c in src_out} == {"dst-a", "dst-b"}
+    assert {c["stream_id"] for c in src_out} == {
+        "deploy.dep.src_dst-a_json",
+        "deploy.dep.src_dst-b_json",
+    }
+
+    src_env = plan["env_plan"].get("src", {})
+    # Sender isn't queued as a plugin so env_plan['src'] is empty; check via
+    # build_env_vars directly to confirm env emission for the sender.
+    from workflow_types import DeployNode as _DN  # noqa: F401
+    src_node = next(n for n in workflow.nodes if n.id == "src")
+    # Re-run wiring to get a populated node (deploy() works on a deep copy).
+    nodes_by_id = {n.id: n.model_copy(deep=True) for n in workflow.nodes}
+    deployment.process_workflow(workflow.edges, nodes_by_id, "ws", "dep")
+    env = deployment.build_env_vars(nodes_by_id["src"])
+    assert env["OUT_JSON_TO_DST_A_STREAM_ID"] == "deploy.dep.src_dst-a_json"
+    assert env["OUT_JSON_TO_DST_B_STREAM_ID"] == "deploy.dep.src_dst-b_json"
+    assert set(env["OUT_JSON_PEERS"].split(",")) == {"DST_A", "DST_B"}
+
+
+def test_fan_in_same_stream_type_keeps_both_subjects() -> None:
+    """One receiver fed by two senders of the same stream type must subscribe
+    to both subjects. Regression test for #78."""
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="src-a", type="sender", out_streams=["json"]),
+            DeployNode(id="src-b", type="sender", out_streams=["json"]),
+            DeployNode(id="sink", type="plugin", in_streams=["json"]),
+        ],
+        edges=[
+            DeployEdge(source="src-a", target="sink", data="json"),
+            DeployEdge(source="src-b", target="sink", data="json"),
+        ],
+    )
+
+    plan = deployment.deploy(workflow, deploy_id="dep", workspace="ws")
+    sink_in = plan["credentials_by_node"]["sink"]["in_creds"]
+    assert len(sink_in) == 2
+    assert {c["peer_id"] for c in sink_in} == {"src-a", "src-b"}
+
+    sink_env = plan["env_plan"]["sink"]
+    assert sink_env["IN_JSON_FROM_SRC_A_STREAM_ID"] == "deploy.dep.src-a_sink_json"
+    assert sink_env["IN_JSON_FROM_SRC_B_STREAM_ID"] == "deploy.dep.src-b_sink_json"
+    assert set(sink_env["IN_JSON_PEERS"].split(",")) == {"SRC_A", "SRC_B"}
+
+
+def test_diamond_topology_wires_all_four_edges() -> None:
+    """Diamond: A -> B, A -> C, B -> D, C -> D. Every node sees both peers."""
+    workflow = DeployWorkflow(
+        nodes=[
+            DeployNode(id="A", type="sender", out_streams=["json"]),
+            DeployNode(id="B", type="plugin", in_streams=["json"], out_streams=["json"]),
+            DeployNode(id="C", type="plugin", in_streams=["json"], out_streams=["json"]),
+            DeployNode(id="D", type="plugin", in_streams=["json"]),
+        ],
+        edges=[
+            DeployEdge(source="A", target="B", data="json"),
+            DeployEdge(source="A", target="C", data="json"),
+            DeployEdge(source="B", target="D", data="json"),
+            DeployEdge(source="C", target="D", data="json"),
+        ],
+    )
+
+    plan = deployment.deploy(workflow, deploy_id="dep", workspace="ws")
+    creds = plan["credentials_by_node"]
+
+    # A fans out to B and C
+    assert {c["peer_id"] for c in creds["A"]["out_creds"]} == {"B", "C"}
+    # D fans in from B and C
+    assert {c["peer_id"] for c in creds["D"]["in_creds"]} == {"B", "C"}
+    # B and C each have one in and one out
+    assert {c["peer_id"] for c in creds["B"]["in_creds"]} == {"A"}
+    assert {c["peer_id"] for c in creds["B"]["out_creds"]} == {"D"}
+    assert {c["peer_id"] for c in creds["C"]["in_creds"]} == {"A"}
+    assert {c["peer_id"] for c in creds["C"]["out_creds"]} == {"D"}
+
+    d_env = plan["env_plan"]["D"]
+    assert "IN_JSON_FROM_B_STREAM_ID" in d_env
+    assert "IN_JSON_FROM_C_STREAM_ID" in d_env

--- a/backend/workflow_types.py
+++ b/backend/workflow_types.py
@@ -31,6 +31,7 @@ class Workflow(BaseModel):
 
 
 class StreamCredential(BaseModel):
+    peer_id: str = ""
     workspace: str
     protocol: str = "pubsub"
     stream_id: str
@@ -44,8 +45,8 @@ class DeployNode(BaseModel):
     runtime: Optional[str] = None
     in_streams: List[str] = Field(default_factory=list)
     out_streams: List[str] = Field(default_factory=list)
-    in_creds: Dict[str, StreamCredential] = Field(default_factory=dict)
-    out_creds: Dict[str, StreamCredential] = Field(default_factory=dict)
+    in_creds: List[StreamCredential] = Field(default_factory=list)
+    out_creds: List[StreamCredential] = Field(default_factory=list)
     env_vars: Dict[str, str] = Field(default_factory=dict)
     data: Dict[str, Any] = Field(default_factory=dict)
 

--- a/cli/lib/transports/nats.js
+++ b/cli/lib/transports/nats.js
@@ -18,6 +18,17 @@ function _withTimeout(promise, ms, what) {
   ])
 }
 
+function _normalizeCreds(credentials) {
+  // The /credentials endpoint now returns a list of {peer_id, stream_id, data_type, ...}
+  // for each edge. Old shape (dict keyed by stream_type) is also accepted so older
+  // backends keep working.
+  if (Array.isArray(credentials)) return credentials
+  if (credentials && typeof credentials === 'object') {
+    return Object.entries(credentials).map(([data_type, cred]) => ({ data_type, ...cred }))
+  }
+  return []
+}
+
 async function connect({ deployId, role, credentials, natsBlock }) {
   if (!natsBlock) {
     throw new Error('nats block missing from credentials response')
@@ -35,31 +46,36 @@ async function connect({ deployId, role, credentials, natsBlock }) {
     'connect',
   )
 
-  const streamTypes = Object.keys(credentials || {})
-  if (streamTypes.length === 0) {
+  const creds = _normalizeCreds(credentials)
+  if (creds.length === 0) {
     throw new Error(`no ${role} credentials found in deployment ${deployId}`)
   }
-  const streamType = streamTypes[0]
-  const cred = credentials[streamType]
 
-  return { role, nc, cred, streamType }
+  return { role, nc, creds }
 }
 
 async function send(handle, message) {
   if (handle.role !== 'sender') throw new Error('send() called on non-sender handle')
-  handle.nc.publish(handle.cred.stream_id, _sc.encode(message))
+  // Fan out to every outbound edge.
+  const data = _sc.encode(message)
+  for (const cred of handle.creds) {
+    handle.nc.publish(cred.stream_id, data)
+  }
   await handle.nc.flush()
 }
 
 async function subscribe(handle, onMessage) {
   if (handle.role !== 'receiver') throw new Error('subscribe() called on non-receiver handle')
-  const sub = handle.nc.subscribe(handle.cred.stream_id)
-  ;(async () => {
-    for await (const msg of sub) {
-      onMessage(_sc.decode(msg.data))
-    }
-  })().catch((e) => { console.error(`[nats] subscriber error: ${e.message}`) })
-  return async () => { await sub.drain() }
+  // Fan in: subscribe to every inbound edge.
+  const subs = handle.creds.map((cred) => handle.nc.subscribe(cred.stream_id))
+  for (const sub of subs) {
+    ;(async () => {
+      for await (const msg of sub) {
+        onMessage(_sc.decode(msg.data))
+      }
+    })().catch((e) => { console.error(`[nats] subscriber error: ${e.message}`) })
+  }
+  return async () => { await Promise.all(subs.map((s) => s.drain())) }
 }
 
 async function close(handle) {

--- a/docs/deploy-contract.md
+++ b/docs/deploy-contract.md
@@ -20,8 +20,8 @@ The frontend and backend share a single deploy payload contract defined by the `
 | `runtime` | `string \| null` | `null` | Container image reference (e.g., `"my-plugin:latest"`) |
 | `in_streams` | `string[]` | `[]` | Stream types this node accepts |
 | `out_streams` | `string[]` | `[]` | Stream types this node produces |
-| `in_creds` | `Record<string, StreamCredential>` | `{}` | Input stream credentials |
-| `out_creds` | `Record<string, StreamCredential>` | `{}` | Output stream credentials |
+| `in_creds` | `StreamCredential[]` | `[]` | Input stream credentials, one per inbound edge |
+| `out_creds` | `StreamCredential[]` | `[]` | Output stream credentials, one per outbound edge |
 | `env_vars` | `Record<string, string>` | `{}` | Environment variables |
 | `data` | `Record<string, any>` | `{}` | Arbitrary metadata (name, description) |
 
@@ -37,11 +37,38 @@ The frontend and backend share a single deploy payload contract defined by the `
 
 | Field | Type | Default |
 |-------|------|---------|
+| `peer_id` | `string` | `""` |
 | `workspace` | `string` | required |
 | `protocol` | `string` | `"pubsub"` |
 | `stream_id` | `string` | required |
 | `data_type` | `string` | required |
 | `metadata` | `Record<string, any>` | `{}` |
+
+`peer_id` is the counterparty node id: for an entry in `in_creds`, it is
+the source node; for `out_creds`, it is the target node. This lets a node
+distinguish multiple inbound or outbound edges of the same `data_type`
+(fan-in / fan-out).
+
+### Plugin env-var contract
+
+For each cred, `build_env_vars` emits four variables. The peer id is
+upper-cased and non-alphanumeric characters become `_`:
+
+```
+IN_<TYPE>_FROM_<PEER>_STREAM_ID
+IN_<TYPE>_FROM_<PEER>_WORKSPACE
+IN_<TYPE>_FROM_<PEER>_PROTOCOL
+IN_<TYPE>_PEERS=peer1,peer2          # comma-separated list per type
+
+OUT_<TYPE>_TO_<PEER>_STREAM_ID
+OUT_<TYPE>_TO_<PEER>_WORKSPACE
+OUT_<TYPE>_TO_<PEER>_PROTOCOL
+OUT_<TYPE>_PEERS=peer3
+```
+
+Plugins that pattern-match on `IN_*_STREAM_ID` / `OUT_*_STREAM_ID` (the
+recommended convention, used by `plugins/caesar_cipher`) automatically
+handle fan-in and fan-out without code changes.
 
 ## Example Request
 
@@ -96,22 +123,26 @@ Content-Type: application/json
     "def-456": {
       "NODE_ID": "def-456",
       "NODE_TYPE": "plugin",
-      "IN_JSON_STREAM_ID": "abc-123_def-456_json_stream",
+      "IN_JSON_FROM_ABC_123_STREAM_ID": "deploy.dep.abc-123_def-456_json",
+      "IN_JSON_FROM_ABC_123_WORKSPACE": "workflow_dep",
+      "IN_JSON_FROM_ABC_123_PROTOCOL": "nats",
+      "IN_JSON_PEERS": "ABC_123",
       "EXISTING": "1"
     }
   },
   "credentials_by_node": {
     "abc-123": {
-      "in_creds": {},
-      "out_creds": {
-        "json": {
-          "workspace": "abc-123_def-456_json_workspace",
-          "protocol": "pubsub",
-          "stream_id": "abc-123_def-456_json_stream",
+      "in_creds": [],
+      "out_creds": [
+        {
+          "peer_id": "def-456",
+          "workspace": "workflow_dep",
+          "protocol": "nats",
+          "stream_id": "deploy.dep.abc-123_def-456_json",
           "data_type": "json",
           "metadata": {}
         }
-      }
+      ]
     }
   },
   "injected_nodes": ["def-456"],


### PR DESCRIPTION
## Summary

The deployment wiring previously stored credentials in `in_creds: Dict[str, StreamCredential]` keyed by stream type alone (`backend/workflow_types.py:47-48`). Two edges of the same type touching the same node silently overwrote each other in the dict — fan-out and fan-in of the same stream type lost channels with no error.

- **Two senders → one receiver (json)**: receiver only saw one upstream
- **One sender → two receivers (json)**: sender only published to one
- The frontend canvas (`onConnect`) and DAG validator (`backend/dag.py`) both accepted these topologies, so the bug was silent.

## Changes

**Schema** (`backend/workflow_types.py`)
- `StreamCredential` gains `peer_id` field
- `DeployNode.in_creds` / `out_creds` are now `List[StreamCredential]` — one per edge

**Wiring** (`backend/deployment.py`)
- `process_workflow` appends per edge, embedding the opposite node's id as `peer_id`
- `build_env_vars` emits per-peer env vars plus `_PEERS` enumerations:
  ```
  IN_<TYPE>_FROM_<PEER>_STREAM_ID  (and _WORKSPACE / _PROTOCOL)
  OUT_<TYPE>_TO_<PEER>_STREAM_ID
  IN_<TYPE>_PEERS=peer1,peer2
  OUT_<TYPE>_PEERS=peer3
  ```
- `credentials_by_node` response shape is now arrays, not dicts

**CLI** (`cli/lib/transports/nats.js`)
- Sender publishes to every outbound subject (true fan-out)
- Receiver subscribes to every inbound subject (true fan-in)
- Includes a back-compat shim accepting the old dict shape from older backends

**Docs** (`docs/deploy-contract.md`)
- Schema rows updated, new "Plugin env-var contract" section, refreshed example response

## Plugin compatibility

`plugins/caesar_cipher` already pattern-matches on `IN_*_STREAM_ID` / `OUT_*_STREAM_ID` (`plugins/caesar_cipher/main.py:29-36`), so it handles the new peer-suffixed names with zero code change — each new env var becomes its own subscription. The recommended convention from the docs covers fan-out/fan-in automatically.

## Test plan

- [x] `tests/test_deployment_planner.py`: existing assertions updated to new env var names
- [x] New regression tests:
  - `test_fan_out_same_stream_type_keeps_both_subjects`
  - `test_fan_in_same_stream_type_keeps_both_subjects`
  - `test_diamond_topology_wires_all_four_edges` (A→B, A→C, B→D, C→D)
- [x] All 13 planner tests pass
- [x] Broader 43-test non-async backend suite green
- [x] CLI 6/6 tests green
- [ ] Manual: deploy a fan-in workflow (two senders → one receiver) and confirm both messages arrive

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)